### PR TITLE
Add Airflow 2/3 support with adapter pattern and OAuth2 auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,28 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for Ap
 
 ## Features
 
+- **Airflow 2.x and 3.x Support**: Automatic version detection with adapter pattern
 - **MCP Tools** for accessing Airflow data:
   - DAG management (list, get details, get source code, stats, warnings, import errors)
   - Task management (list, get details, get task instances)
   - Pool management (list, get details)
   - Variable management (list, get specific variables)
+  - Asset/Dataset management (unified naming across versions)
   - Plugin and provider information
   - Configuration and version details
-
+- **Consolidated Tools** for agent workflows:
+  - `explore_dag`: Get comprehensive DAG information in one call
+  - `diagnose_dag_run`: Debug failed DAG runs with task instance details
+  - `get_system_health`: System overview with health, errors, and warnings
+- **MCP Resources**: Static Airflow info exposed as resources (version, providers, plugins, config)
+- **MCP Prompts**: Guided workflows for common tasks (troubleshooting, health checks, onboarding)
 - **Dual deployment modes**:
   - **Standalone server**: Run as an independent MCP server
   - **Airflow plugin**: Integrate directly into Airflow 3.x webserver
-
-- **Authentication support**: Bearer token authentication
+- **Flexible Authentication**:
+  - Bearer token (Airflow 2.x and 3.x)
+  - Username/password with automatic OAuth2 token exchange (Airflow 3.x)
+  - Basic auth (Airflow 2.x)
 
 
 ## Installation
@@ -58,7 +67,10 @@ The server provides a set of tools that AI assistants can use to interact with y
 **Custom configuration:**
 
 ```bash
-# Connect to a different Airflow instance
+# Airflow 3.x with username/password (OAuth2 token exchange)
+astro-airflow-mcp --airflow-url https://my-airflow.example.com --username admin --password admin
+
+# Airflow 2.x or 3.x with bearer token
 astro-airflow-mcp --airflow-url https://my-airflow.example.com --auth-token my_token
 
 # Use a different port
@@ -73,6 +85,23 @@ astro-airflow-mcp --transport stdio
 #### Claude Desktop
 
 Add to your Claude Desktop configuration:
+
+```json
+{
+  "mcpServers": {
+    "airflow": {
+      "command": "astro-airflow-mcp",
+      "env": {
+        "AIRFLOW_API_URL": "http://your.airflow.domain.com",
+        "AIRFLOW_USERNAME": "admin",
+        "AIRFLOW_PASSWORD": "admin"
+      }
+    }
+  }
+}
+```
+
+Or with a bearer token:
 
 ```json
 {
@@ -132,14 +161,22 @@ Configure in Cursor's MCP settings:
 
 ## Available Tools
 
-The MCP server provides the following tools:
+### Consolidated Tools (Agent-Optimized)
+
+| Tool | Description |
+|------|-------------|
+| `explore_dag` | Get comprehensive DAG info: metadata, tasks, recent runs, source code |
+| `diagnose_dag_run` | Debug a DAG run: run details, failed task instances, logs |
+| `get_system_health` | System overview: health status, import errors, warnings, DAG stats |
+
+### Core Tools
 
 | Tool | Description |
 |------|-------------|
 | `list_dags` | Get all DAGs and their metadata |
 | `get_dag_details` | Get detailed info about a specific DAG |
 | `get_dag_source` | Get the source code of a DAG |
-| `get_dag_stats` | Get DAG run statistics |
+| `get_dag_stats` | Get DAG run statistics (Airflow 3.x only) |
 | `list_dag_warnings` | Get DAG import warnings |
 | `list_import_errors` | Get import errors from DAG files that failed to parse |
 | `list_tasks` | Get all tasks in a DAG |
@@ -149,13 +186,27 @@ The MCP server provides the following tools:
 | `get_pool` | Get details about a specific pool |
 | `list_variables` | Get all Airflow variables |
 | `get_variable` | Get a specific variable by key |
-| `list_plugins` | Get installed Airflow plugins |
-| `list_providers` | Get installed provider packages |
-| `get_airflow_config` | Get Airflow configuration |
-| `get_airflow_version` | Get Airflow version information |
+| `list_assets` | Get assets/datasets (unified naming across versions) |
 | `list_dag_runs` | Get DAG run history |
 | `get_dag_run` | Get specific DAG run details |
 | `get_health` | Get Airflow health status |
+
+### MCP Resources
+
+| Resource URI | Description |
+|--------------|-------------|
+| `airflow://version` | Airflow version information |
+| `airflow://providers` | Installed provider packages |
+| `airflow://plugins` | Installed Airflow plugins |
+| `airflow://config` | Airflow configuration |
+
+### MCP Prompts
+
+| Prompt | Description |
+|--------|-------------|
+| `troubleshoot_failed_dag` | Guided workflow for diagnosing DAG failures |
+| `daily_health_check` | Morning health check routine |
+| `onboard_new_dag` | Guide for understanding a new DAG |
 
 ## Development
 
@@ -197,19 +248,38 @@ All tools use a global configuration that can be set via:
 1. **Command-line flags** (standalone mode):
    - `--airflow-url`: Airflow webserver URL
    - `--auth-token`: Bearer token for authentication
+   - `--username`: Username for authentication (Airflow 3.x uses OAuth2 token exchange)
+   - `--password`: Password for authentication
 
 2. **Environment variables**:
    - `AIRFLOW_API_URL`: Airflow webserver URL
    - `AIRFLOW_AUTH_TOKEN`: Bearer token
+   - `AIRFLOW_USERNAME`: Username for authentication
+   - `AIRFLOW_PASSWORD`: Password for authentication
 
 ## Architecture
 
-The server is built using [FastMCP](https://github.com/jlowin/fastmcp), which provides:
-- Native MCP protocol support (SSE + JSON-RPC)
-- Easy integration with FastAPI applications
-- Automatic tool registration via decorators
+The server is built using [FastMCP](https://github.com/jlowin/fastmcp) with an adapter pattern for Airflow version compatibility:
 
-In standalone mode, it runs as an independent ASGI application. In plugin mode, it's mounted into Airflow's FastAPI webserver using Airflow 3.x's plugin system.
+### Core Components
+
+- **Adapters** (`adapters/`): Version-specific API implementations
+  - `AirflowAdapter` (base): Abstract interface for all Airflow API operations
+  - `AirflowV2Adapter`: Airflow 2.x API (`/api/v1`) with basic auth
+  - `AirflowV3Adapter`: Airflow 3.x API (`/api/v2`) with OAuth2 token exchange
+- **Version Detection**: Automatic detection at startup by probing API endpoints
+- **Models** (`models.py`): Pydantic models for type-safe API responses
+
+### Version Handling Strategy
+
+1. **Major versions (2.x vs 3.x)**: Adapter pattern with runtime version detection
+2. **Minor versions (3.1 vs 3.2)**: Runtime feature detection with graceful fallbacks
+3. **New API parameters**: Pass-through `**kwargs` for forward compatibility
+
+### Deployment Modes
+
+- **Standalone**: Independent ASGI application with HTTP/SSE transport
+- **Plugin**: Mounted into Airflow 3.x FastAPI webserver
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "fastmcp>=0.1.0",
-    "requests>=2.31.0",
+    "httpx>=0.27.0",
+    "pydantic>=2.0.0",
 ]
 
 [project.optional-dependencies]
@@ -35,15 +36,15 @@ packages = ["src/astro_airflow_mcp"]
 [tool.hatchling.build.targets.wheel.force-include]
 "src/astro_airflow_mcp/templates" = "astro_airflow_mcp/templates"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=7.0.0",
     "pytest-mock>=3.12.0",
+    "pytest-httpx>=0.30.0",
     "ruff>=0.1.0",
     "pre-commit>=3.5.0",
     "mypy>=1.8.0",
     "bandit[toml]>=1.7.0",
-    "types-requests>=2.31.0",
 ]
 
 [tool.ruff]

--- a/src/astro_airflow_mcp/__main__.py
+++ b/src/astro_airflow_mcp/__main__.py
@@ -48,6 +48,18 @@ def main():
         default=os.getenv("AIRFLOW_AUTH_TOKEN"),
         help="Bearer token for Airflow API authentication",
     )
+    parser.add_argument(
+        "--username",
+        type=str,
+        default=os.getenv("AIRFLOW_USERNAME"),
+        help="Username for basic authentication",
+    )
+    parser.add_argument(
+        "--password",
+        type=str,
+        default=os.getenv("AIRFLOW_PASSWORD"),
+        help="Password for basic authentication",
+    )
 
     args = parser.parse_args()
 
@@ -55,12 +67,16 @@ def main():
     configure(
         url=args.airflow_url,
         auth_token=args.auth_token,
+        username=args.username,
+        password=args.password,
     )
 
     # Log Airflow connection configuration
     logger.info(f"Airflow URL: {args.airflow_url}")
     if args.auth_token:
         logger.info("Authentication: Bearer token")
+    elif args.username and args.password:
+        logger.info(f"Authentication: Basic auth (user: {args.username})")
     else:
         logger.info("Authentication: None")
 

--- a/src/astro_airflow_mcp/adapters/__init__.py
+++ b/src/astro_airflow_mcp/adapters/__init__.py
@@ -1,0 +1,182 @@
+"""Adapter factory for creating version-specific Airflow clients."""
+
+import httpx
+
+from astro_airflow_mcp.adapters.airflow_v2 import AirflowV2Adapter
+from astro_airflow_mcp.adapters.airflow_v3 import AirflowV3Adapter
+from astro_airflow_mcp.adapters.base import AirflowAdapter, NotFoundError
+
+
+def _get_jwt_token(airflow_url: str, username: str, password: str) -> str | None:
+    """Attempt to get a JWT token via OAuth2 (Airflow 3 style).
+
+    Args:
+        airflow_url: Base URL of Airflow webserver
+        username: Airflow username
+        password: Airflow password
+
+    Returns:
+        JWT access token if successful, None otherwise
+    """
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            response = client.post(
+                f"{airflow_url}/auth/token",
+                data={"username": username, "password": password},
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+            if response.status_code == 200:
+                data = response.json()
+                return data.get("access_token")
+    except Exception:  # noqa: S110 - intentionally silent, fallback to other auth
+        return None
+    return None
+
+
+def detect_version(
+    airflow_url: str,
+    auth_token: str | None = None,
+    username: str | None = None,
+    password: str | None = None,
+) -> tuple[int, str]:
+    """Detect Airflow version by probing API endpoints.
+
+    Auth strategy:
+    - If auth_token is provided, use it as Bearer token
+    - For Airflow 3: Try OAuth2 token exchange (username/password -> JWT)
+    - For Airflow 2: Use basic auth (username/password)
+
+    Args:
+        airflow_url: Base URL of Airflow webserver
+        auth_token: Optional Bearer token
+        username: Optional username for auth
+        password: Optional password for auth
+
+    Returns:
+        Tuple of (major_version, full_version_string)
+
+    Raises:
+        RuntimeError: If version detection fails
+    """
+    headers: dict[str, str] = {}
+    auth: tuple[str, str] | None = None
+
+    if auth_token:
+        headers["Authorization"] = f"Bearer {auth_token}"
+
+    # Try Airflow 3 API first (/api/v2/version)
+    # Airflow 3 uses OAuth2 - try to get JWT if we have username/password
+    jwt_token = None
+    if not auth_token and username and password:
+        jwt_token = _get_jwt_token(airflow_url, username, password)
+        if jwt_token:
+            headers["Authorization"] = f"Bearer {jwt_token}"
+
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            response = client.get(
+                f"{airflow_url}/api/v2/version",
+                headers=headers,
+            )
+            if response.status_code == 200:
+                data = response.json()
+                version = data.get("version", "3.0.0")
+                major = int(version.split(".")[0])
+                return (major, version)
+    except Exception:  # nosec B110 - try v2 API next
+        pass
+
+    # Try Airflow 2 API (/api/v1/version)
+    # Airflow 2 uses basic auth
+    headers_v2: dict[str, str] = {}
+    if auth_token:
+        headers_v2["Authorization"] = f"Bearer {auth_token}"
+    elif username and password:
+        auth = (username, password)
+    else:
+        # Default to admin:admin for Airflow 2 (common dev default)
+        auth = ("admin", "admin")  # noqa: S105
+
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            response = client.get(
+                f"{airflow_url}/api/v1/version",
+                headers=headers_v2,
+                auth=auth,
+            )
+            if response.status_code == 200:
+                data = response.json()
+                version = data.get("version", "2.0.0")
+                major = int(version.split(".")[0])
+                return (major, version)
+    except Exception:  # nosec B110 - raise RuntimeError below
+        pass
+
+    raise RuntimeError(
+        f"Failed to detect Airflow version at {airflow_url}. "
+        "Ensure Airflow is running and accessible."
+    )
+
+
+def create_adapter(
+    airflow_url: str,
+    auth_token: str | None = None,
+    username: str | None = None,
+    password: str | None = None,
+) -> AirflowAdapter:
+    """Create appropriate adapter based on detected Airflow version.
+
+    Args:
+        airflow_url: Base URL of Airflow webserver
+        auth_token: Optional Bearer token (alternative to username/password)
+        username: Optional username for basic auth
+        password: Optional password for basic auth
+
+    Returns:
+        Version-specific adapter instance
+
+    Raises:
+        RuntimeError: If version detection fails or version is unsupported
+
+    Note:
+        - Airflow 2.x typically requires basic auth (defaults to admin:admin if not provided)
+        - Airflow 3.x is typically open (no auth) unless explicitly configured
+    """
+    major_version, full_version = detect_version(
+        airflow_url, auth_token=auth_token, username=username, password=password
+    )
+
+    # Apply version-specific auth defaults
+    if major_version == 2:
+        # Airflow 2.x typically requires basic auth
+        if not auth_token and not username and not password:
+            # Default Airflow 2 dev credentials
+            username = "admin"  # nosec B105
+            password = "admin"  # nosec B105
+        return AirflowV2Adapter(
+            airflow_url,
+            full_version,
+            auth_token=auth_token,
+            username=username,
+            password=password,
+        )
+    elif major_version >= 3:
+        return AirflowV3Adapter(
+            airflow_url,
+            full_version,
+            auth_token=auth_token,
+            username=username,
+            password=password,
+        )
+    else:
+        raise RuntimeError(f"Unsupported Airflow version: {major_version}")
+
+
+__all__ = [
+    "AirflowAdapter",
+    "AirflowV2Adapter",
+    "AirflowV3Adapter",
+    "NotFoundError",
+    "create_adapter",
+    "detect_version",
+]

--- a/src/astro_airflow_mcp/adapters/airflow_v2.py
+++ b/src/astro_airflow_mcp/adapters/airflow_v2.py
@@ -1,0 +1,152 @@
+"""Adapter for Airflow 2.x API."""
+
+from typing import Any
+
+from astro_airflow_mcp.adapters.base import AirflowAdapter, NotFoundError
+
+
+class AirflowV2Adapter(AirflowAdapter):
+    """Adapter for Airflow 2.x API (/api/v1)."""
+
+    @property
+    def api_base_path(self) -> str:
+        """API base path for Airflow 2.x."""
+        return "/api/v1"
+
+    def list_dags(self, limit: int = 100, offset: int = 0, **kwargs: Any) -> dict[str, Any]:
+        """List all DAGs."""
+        return self._call("dags", params={"limit": limit, "offset": offset}, **kwargs)
+
+    def get_dag(self, dag_id: str) -> dict[str, Any]:
+        """Get details of a specific DAG."""
+        return self._call(f"dags/{dag_id}")
+
+    def get_dag_source(self, dag_id: str) -> dict[str, Any]:
+        """Get source code of a DAG.
+
+        Note: Airflow 2 requires a file_token, so we get DAG details first.
+        """
+        # First, get the DAG to get its file_token
+        dag_data = self.get_dag(dag_id)
+        file_token = dag_data.get("file_token")
+        if not file_token:
+            return {"error": "DAG has no file_token", "dag_id": dag_id}
+
+        # Get source using file_token
+        return self._call(f"dagSources/{file_token}")
+
+    def list_dag_runs(
+        self, dag_id: str | None = None, limit: int = 100, offset: int = 0, **kwargs: Any
+    ) -> dict[str, Any]:
+        """List DAG runs.
+
+        Note: Airflow 2 requires dag_id. Use '~' to list runs for all DAGs.
+        """
+        dag_id_param = dag_id if dag_id else "~"
+        return self._call(
+            f"dags/{dag_id_param}/dagRuns",
+            params={"limit": limit, "offset": offset},
+            **kwargs,
+        )
+
+    def get_dag_run(self, dag_id: str, dag_run_id: str) -> dict[str, Any]:
+        """Get details of a specific DAG run."""
+        return self._call(f"dags/{dag_id}/dagRuns/{dag_run_id}")
+
+    def list_tasks(self, dag_id: str) -> dict[str, Any]:
+        """List all tasks in a DAG."""
+        return self._call(f"dags/{dag_id}/tasks")
+
+    def get_task(self, dag_id: str, task_id: str) -> dict[str, Any]:
+        """Get details of a specific task."""
+        return self._call(f"dags/{dag_id}/tasks/{task_id}")
+
+    def get_task_instance(self, dag_id: str, dag_run_id: str, task_id: str) -> dict[str, Any]:
+        """Get details of a task instance."""
+        return self._call(f"dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}")
+
+    def list_assets(self, limit: int = 100, offset: int = 0, **kwargs: Any) -> dict[str, Any]:
+        """List assets (called 'datasets' in Airflow 2).
+
+        Normalizes field names for consistency with Airflow 3:
+        - 'datasets' -> 'assets'
+        - 'consuming_dags' -> 'scheduled_dags'
+        """
+        try:
+            data = self._call("datasets", params={"limit": limit, "offset": offset}, **kwargs)
+
+            # Normalize field names
+            if "datasets" in data:
+                data["assets"] = data.pop("datasets")
+                for asset in data.get("assets", []):
+                    if "consuming_dags" in asset:
+                        asset["scheduled_dags"] = asset.pop("consuming_dags")
+
+            return data
+        except NotFoundError:
+            return self._handle_not_found(
+                "datasets", alternative="Datasets/Assets were added in Airflow 2.4"
+            )
+
+    def list_variables(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        """List Airflow variables."""
+        return self._call("variables", params={"limit": limit, "offset": offset})
+
+    def get_variable(self, variable_key: str) -> dict[str, Any]:
+        """Get a specific variable."""
+        return self._call(f"variables/{variable_key}")
+
+    def list_connections(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        """List Airflow connections (passwords filtered)."""
+        data = self._call("connections", params={"limit": limit, "offset": offset})
+        return self._filter_passwords(data)
+
+    def list_pools(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        """List Airflow pools."""
+        return self._call("pools", params={"limit": limit, "offset": offset})
+
+    def get_pool(self, pool_name: str) -> dict[str, Any]:
+        """Get details of a specific pool."""
+        return self._call(f"pools/{pool_name}")
+
+    def get_dag_stats(self, dag_ids: list[str] | None = None) -> dict[str, Any]:
+        """Get DAG run statistics.
+
+        Note: dagStats endpoint is only available in Airflow 3.x.
+        """
+        return self._handle_not_found(
+            "dagStats", alternative="Use list_dag_runs to get DAG run information"
+        )
+
+    def list_dag_warnings(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        """List DAG warnings."""
+        return self._call("dagWarnings", params={"limit": limit, "offset": offset})
+
+    def list_import_errors(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        """List import errors from DAG files."""
+        return self._call("importErrors", params={"limit": limit, "offset": offset})
+
+    def list_plugins(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        """List installed Airflow plugins."""
+        return self._call("plugins", params={"limit": limit, "offset": offset})
+
+    def list_providers(self) -> dict[str, Any]:
+        """List installed Airflow provider packages."""
+        return self._call("providers")
+
+    def get_version(self) -> dict[str, Any]:
+        """Get Airflow version info."""
+        return self._call("version")
+
+    def get_config(self) -> dict[str, Any]:
+        """Get Airflow configuration.
+
+        Note: Airflow 2.x config endpoint may require specific permissions.
+        """
+        try:
+            return self._call("config")
+        except Exception as e:
+            return {
+                "error": str(e),
+                "note": "Config endpoint may require expose_config=True in airflow.cfg",
+            }

--- a/src/astro_airflow_mcp/adapters/airflow_v3.py
+++ b/src/astro_airflow_mcp/adapters/airflow_v3.py
@@ -1,0 +1,290 @@
+"""Adapter for Airflow 3.x API."""
+
+from typing import Any
+
+import httpx
+
+from astro_airflow_mcp.adapters.base import AirflowAdapter, NotFoundError
+
+
+class AirflowV3Adapter(AirflowAdapter):
+    """Adapter for Airflow 3.x API (/api/v2).
+
+    Airflow 3.x uses OAuth2 Password Bearer authentication:
+    - If auth_token is provided, it's used directly as a Bearer token
+    - If username/password are provided, the adapter exchanges them for a JWT
+      via the /auth/token endpoint and uses the JWT for subsequent calls
+
+    See: https://github.com/apache/airflow-client-python
+    """
+
+    def __init__(
+        self,
+        airflow_url: str,
+        version: str,
+        auth_token: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+    ):
+        """Initialize Airflow 3 adapter with OAuth2 token support.
+
+        Args:
+            airflow_url: Base URL of Airflow webserver
+            version: Full version string (e.g., "3.2.0")
+            auth_token: Optional pre-obtained JWT token
+            username: Optional username for OAuth2 token exchange
+            password: Optional password for OAuth2 token exchange
+        """
+        # If username/password provided but no token, exchange for JWT
+        if username and password and not auth_token:
+            auth_token = self._exchange_for_token(airflow_url, username, password)
+
+        # Call parent with the token (password auth now converted to JWT)
+        super().__init__(airflow_url, version, auth_token=auth_token)
+
+    @staticmethod
+    def _exchange_for_token(airflow_url: str, username: str, password: str) -> str:
+        """Exchange username/password for a JWT token via OAuth2 endpoint.
+
+        Airflow 3 uses OAuth2 Password Bearer flow - POST credentials to
+        /auth/token and receive a JWT access_token.
+
+        Args:
+            airflow_url: Base URL of Airflow webserver
+            username: Airflow username
+            password: Airflow password
+
+        Returns:
+            JWT access token string
+
+        Raises:
+            RuntimeError: If token exchange fails
+        """
+        token_url = f"{airflow_url}/auth/token"
+        try:
+            with httpx.Client(timeout=10.0) as client:
+                response = client.post(
+                    token_url,
+                    data={"username": username, "password": password},
+                    headers={"Content-Type": "application/x-www-form-urlencoded"},
+                )
+                response.raise_for_status()
+                data = response.json()
+                token = data.get("access_token")
+                if not token:
+                    raise RuntimeError(f"No access_token in response from {token_url}")
+                return token
+        except httpx.HTTPStatusError as e:
+            raise RuntimeError(
+                f"Failed to obtain JWT token from {token_url}: "
+                f"{e.response.status_code} - {e.response.text}"
+            ) from e
+        except httpx.RequestError as e:
+            raise RuntimeError(f"Failed to connect to {token_url}: {e}") from e
+
+    @property
+    def api_base_path(self) -> str:
+        """API base path for Airflow 3.x."""
+        return "/api/v2"
+
+    def list_dags(self, limit: int = 100, offset: int = 0, **kwargs: Any) -> dict[str, Any]:
+        """List all DAGs with optional filters.
+
+        Args:
+            limit: Maximum number of DAGs to return
+            offset: Offset for pagination
+            **kwargs: Additional filters (e.g., tags, paused, only_active)
+                      Passed through to Airflow API for forward compatibility.
+        """
+        return self._call("dags", params={"limit": limit, "offset": offset}, **kwargs)
+
+    def get_dag(self, dag_id: str) -> dict[str, Any]:
+        """Get details of a specific DAG."""
+        return self._call(f"dags/{dag_id}")
+
+    def get_dag_source(self, dag_id: str) -> dict[str, Any]:
+        """Get source code of a DAG.
+
+        Note: Airflow 3 directly uses dag_id for source lookup.
+        """
+        return self._call(f"dagSources/{dag_id}")
+
+    def list_dag_runs(
+        self, dag_id: str | None = None, limit: int = 100, offset: int = 0, **kwargs: Any
+    ) -> dict[str, Any]:
+        """List DAG runs.
+
+        Args:
+            dag_id: Optional DAG ID. Use '~' or None for all DAGs.
+            limit: Maximum number of runs to return
+            offset: Offset for pagination
+            **kwargs: Additional filters (e.g., state, start_date_gte)
+        """
+        dag_id_param = dag_id if dag_id else "~"
+        return self._call(
+            f"dags/{dag_id_param}/dagRuns",
+            params={"limit": limit, "offset": offset},
+            **kwargs,
+        )
+
+    def get_dag_run(self, dag_id: str, dag_run_id: str) -> dict[str, Any]:
+        """Get details of a specific DAG run."""
+        return self._call(f"dags/{dag_id}/dagRuns/{dag_run_id}")
+
+    def list_tasks(self, dag_id: str) -> dict[str, Any]:
+        """List all tasks in a DAG."""
+        return self._call(f"dags/{dag_id}/tasks")
+
+    def get_task(self, dag_id: str, task_id: str) -> dict[str, Any]:
+        """Get details of a specific task."""
+        return self._call(f"dags/{dag_id}/tasks/{task_id}")
+
+    def get_task_instance(self, dag_id: str, dag_run_id: str, task_id: str) -> dict[str, Any]:
+        """Get details of a task instance."""
+        return self._call(f"dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}")
+
+    def list_assets(self, limit: int = 100, offset: int = 0, **kwargs: Any) -> dict[str, Any]:
+        """List assets (renamed from 'datasets' in Airflow 3)."""
+        try:
+            return self._call("assets", params={"limit": limit, "offset": offset}, **kwargs)
+        except NotFoundError:
+            return self._handle_not_found(
+                "assets", alternative="Try 'datasets' endpoint if using older Airflow 3.x"
+            )
+
+    def list_variables(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        """List Airflow variables."""
+        return self._call("variables", params={"limit": limit, "offset": offset})
+
+    def get_variable(self, variable_key: str) -> dict[str, Any]:
+        """Get a specific variable."""
+        return self._call(f"variables/{variable_key}")
+
+    def list_connections(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        """List Airflow connections (passwords filtered)."""
+        data = self._call("connections", params={"limit": limit, "offset": offset})
+        return self._filter_passwords(data)
+
+    def list_pools(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        """List Airflow pools."""
+        return self._call("pools", params={"limit": limit, "offset": offset})
+
+    def get_pool(self, pool_name: str) -> dict[str, Any]:
+        """Get details of a specific pool."""
+        return self._call(f"pools/{pool_name}")
+
+    def get_dag_stats(self, dag_ids: list[str] | None = None) -> dict[str, Any]:
+        """Get DAG run statistics by state.
+
+        Args:
+            dag_ids: Optional list of DAG IDs to get stats for.
+                     If None, returns stats for all DAGs.
+
+        Note:
+            Airflow 3.2.0 has bugs where:
+            1. Calling without dag_ids causes a 500 error
+            2. Multiple dag_ids in one call causes a 500 error
+            3. DAGs with dag_display_name=None cause a 500 error
+
+            We work around these by calling once per DAG and handling errors.
+
+        Available in Airflow 3.0+. Returns counts by DAG and state.
+        """
+        try:
+            # Workaround for Airflow 3.2.0 bugs
+            if dag_ids:
+                # Call once per DAG to avoid multiple dag_ids bug
+                all_results: dict[str, Any] = {"dags": [], "total_entries": 0, "errors": []}
+                for dag_id in dag_ids:
+                    try:
+                        result = self._call("dagStats", params={"dag_ids": dag_id})
+                        all_results["dags"].extend(result.get("dags", []))
+                        all_results["total_entries"] += result.get("total_entries", 0)
+                    except Exception as e:
+                        # Some DAGs may fail due to dag_display_name=None bug
+                        all_results["errors"].append(
+                            {
+                                "dag_id": dag_id,
+                                "error": str(e),
+                                "note": "Airflow 3.2.0 bug: dag_display_name may be None",
+                            }
+                        )
+                if not all_results["errors"]:
+                    del all_results["errors"]
+                return all_results
+            else:
+                # Pass empty dag_ids to avoid 500 error
+                return self._call("dagStats", params={"dag_ids": ""})
+        except NotFoundError:
+            return self._handle_not_found(
+                "dagStats", alternative="Use list_dag_runs to compute statistics"
+            )
+
+    def list_dag_warnings(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        """List DAG warnings."""
+        return self._call("dagWarnings", params={"limit": limit, "offset": offset})
+
+    def list_import_errors(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        """List import errors from DAG files."""
+        return self._call("importErrors", params={"limit": limit, "offset": offset})
+
+    def list_plugins(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        """List installed Airflow plugins."""
+        return self._call("plugins", params={"limit": limit, "offset": offset})
+
+    def list_providers(self) -> dict[str, Any]:
+        """List installed Airflow provider packages."""
+        return self._call("providers")
+
+    def get_version(self) -> dict[str, Any]:
+        """Get Airflow version info."""
+        return self._call("version")
+
+    def get_config(self) -> dict[str, Any]:
+        """Get Airflow configuration."""
+        return self._call("config")
+
+    # Airflow 3.x specific features
+
+    def get_task_instances(
+        self, dag_id: str, dag_run_id: str, limit: int = 100, offset: int = 0
+    ) -> dict[str, Any]:
+        """List all task instances for a DAG run.
+
+        Args:
+            dag_id: DAG ID
+            dag_run_id: DAG run ID
+            limit: Maximum number of task instances to return
+            offset: Offset for pagination
+
+        Available in Airflow 3.0+.
+        """
+        try:
+            return self._call(
+                f"dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances",
+                params={"limit": limit, "offset": offset},
+            )
+        except NotFoundError:
+            return self._handle_not_found(f"dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances")
+
+    def get_task_logs(
+        self, dag_id: str, dag_run_id: str, task_id: str, try_number: int = 1
+    ) -> dict[str, Any]:
+        """Get logs for a specific task instance.
+
+        Args:
+            dag_id: DAG ID
+            dag_run_id: DAG run ID
+            task_id: Task ID
+            try_number: Try number for the task (default 1)
+
+        Available in Airflow 3.0+.
+        """
+        try:
+            return self._call(
+                f"dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/logs/{try_number}"
+            )
+        except NotFoundError:
+            return self._handle_not_found(
+                "task logs", alternative="Check if the task instance exists and has been executed"
+            )

--- a/src/astro_airflow_mcp/adapters/base.py
+++ b/src/astro_airflow_mcp/adapters/base.py
@@ -1,0 +1,258 @@
+"""Base adapter interface for Airflow API clients."""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+import httpx
+
+
+class NotFoundError(Exception):
+    """Raised when an API endpoint returns 404."""
+
+    def __init__(self, endpoint: str):
+        self.endpoint = endpoint
+        super().__init__(f"Endpoint not found: {endpoint}")
+
+
+class AirflowAdapter(ABC):
+    """Abstract base class for Airflow API adapters.
+
+    Adapters wrap version-specific API calls and provide a consistent
+    interface for the MCP server tools.
+    """
+
+    def __init__(
+        self,
+        airflow_url: str,
+        version: str,
+        auth_token: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+    ):
+        """Initialize adapter with connection details.
+
+        Args:
+            airflow_url: Base URL of Airflow webserver
+            version: Full version string (e.g., "3.1.3")
+            auth_token: Optional Bearer token for authentication
+            username: Optional username for basic auth
+            password: Optional password for basic auth
+        """
+        self.airflow_url = airflow_url
+        self.version = version
+        self.auth_token = auth_token
+        self.username = username
+        self.password = password
+
+    @property
+    @abstractmethod
+    def api_base_path(self) -> str:
+        """API base path for this version (e.g., '/api/v1' or '/api/v2')."""
+        pass
+
+    def _setup_auth(self) -> tuple[dict[str, str], tuple[str, str] | None]:
+        """Set up authentication headers and credentials.
+
+        Returns:
+            Tuple of (headers dict, auth tuple or None)
+        """
+        headers: dict[str, str] = {}
+        auth: tuple[str, str] | None = None
+
+        if self.auth_token:
+            headers["Authorization"] = f"Bearer {self.auth_token}"
+        elif self.username and self.password:
+            auth = (self.username, self.password)
+
+        return headers, auth
+
+    def _call(
+        self,
+        endpoint: str,
+        params: dict[str, Any] | None = None,
+        **extra_params: Any,
+    ) -> dict[str, Any]:
+        """Make HTTP call to Airflow API.
+
+        Args:
+            endpoint: API endpoint path (without base path)
+            params: Query parameters
+            **extra_params: Additional query parameters (pass-through)
+
+        Returns:
+            Parsed JSON response
+
+        Raises:
+            NotFoundError: If endpoint returns 404
+            Exception: For other HTTP errors
+        """
+        headers, auth = self._setup_auth()
+        url = f"{self.airflow_url}{self.api_base_path}/{endpoint}"
+
+        # Merge params with extra_params for forward compatibility
+        all_params = {**(params or {}), **extra_params}
+        # Remove None values
+        all_params = {k: v for k, v in all_params.items() if v is not None}
+
+        with httpx.Client(timeout=30.0) as client:
+            response = client.get(url, params=all_params, headers=headers, auth=auth)
+
+            if response.status_code == 404:
+                raise NotFoundError(endpoint)
+
+            response.raise_for_status()
+            return response.json()
+
+    def _handle_not_found(self, endpoint: str, alternative: str | None = None) -> dict[str, Any]:
+        """Create a structured response for unavailable endpoints.
+
+        Args:
+            endpoint: The endpoint that was not found
+            alternative: Suggested alternative approach
+
+        Returns:
+            Dict with availability info and alternative
+        """
+        result: dict[str, Any] = {
+            "available": False,
+            "note": f"Endpoint '{endpoint}' not available in Airflow {self.version}",
+        }
+        if alternative:
+            result["alternative"] = alternative
+        return result
+
+    def _filter_passwords(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Filter password fields from connection data for security.
+
+        Args:
+            data: Dict containing connection data
+
+        Returns:
+            Dict with passwords filtered out
+        """
+        if "connections" in data:
+            for conn in data["connections"]:
+                if "password" in conn:
+                    conn["password"] = "***FILTERED***"  # nosec B105
+        return data
+
+    # DAG Operations
+    @abstractmethod
+    def list_dags(self, limit: int = 100, offset: int = 0, **kwargs: Any) -> dict[str, Any]:
+        """List all DAGs."""
+        pass
+
+    @abstractmethod
+    def get_dag(self, dag_id: str) -> dict[str, Any]:
+        """Get details of a specific DAG."""
+        pass
+
+    @abstractmethod
+    def get_dag_source(self, dag_id: str) -> dict[str, Any]:
+        """Get source code of a DAG."""
+        pass
+
+    # DAG Run Operations
+    @abstractmethod
+    def list_dag_runs(
+        self, dag_id: str | None = None, limit: int = 100, offset: int = 0, **kwargs: Any
+    ) -> dict[str, Any]:
+        """List DAG runs."""
+        pass
+
+    @abstractmethod
+    def get_dag_run(self, dag_id: str, dag_run_id: str) -> dict[str, Any]:
+        """Get details of a specific DAG run."""
+        pass
+
+    # Task Operations
+    @abstractmethod
+    def list_tasks(self, dag_id: str) -> dict[str, Any]:
+        """List all tasks in a DAG."""
+        pass
+
+    @abstractmethod
+    def get_task(self, dag_id: str, task_id: str) -> dict[str, Any]:
+        """Get details of a specific task."""
+        pass
+
+    @abstractmethod
+    def get_task_instance(self, dag_id: str, dag_run_id: str, task_id: str) -> dict[str, Any]:
+        """Get details of a task instance."""
+        pass
+
+    # Asset/Dataset Operations
+    @abstractmethod
+    def list_assets(self, limit: int = 100, offset: int = 0, **kwargs: Any) -> dict[str, Any]:
+        """List assets/datasets."""
+        pass
+
+    # Variable Operations
+    @abstractmethod
+    def list_variables(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        """List Airflow variables."""
+        pass
+
+    @abstractmethod
+    def get_variable(self, variable_key: str) -> dict[str, Any]:
+        """Get a specific variable."""
+        pass
+
+    # Connection Operations
+    @abstractmethod
+    def list_connections(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        """List Airflow connections (passwords filtered)."""
+        pass
+
+    # Pool Operations
+    @abstractmethod
+    def list_pools(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        """List Airflow pools."""
+        pass
+
+    @abstractmethod
+    def get_pool(self, pool_name: str) -> dict[str, Any]:
+        """Get details of a specific pool."""
+        pass
+
+    # DAG Statistics and Warnings
+    @abstractmethod
+    def get_dag_stats(self, dag_ids: list[str] | None = None) -> dict[str, Any]:
+        """Get DAG run statistics by state.
+
+        Args:
+            dag_ids: Optional list of DAG IDs to get stats for.
+        """
+        pass
+
+    @abstractmethod
+    def list_dag_warnings(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        """List DAG warnings."""
+        pass
+
+    @abstractmethod
+    def list_import_errors(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        """List import errors from DAG files."""
+        pass
+
+    # Plugin and Provider Operations
+    @abstractmethod
+    def list_plugins(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        """List installed Airflow plugins."""
+        pass
+
+    @abstractmethod
+    def list_providers(self) -> dict[str, Any]:
+        """List installed Airflow provider packages."""
+        pass
+
+    # System Operations
+    @abstractmethod
+    def get_version(self) -> dict[str, Any]:
+        """Get Airflow version info."""
+        pass
+
+    @abstractmethod
+    def get_config(self) -> dict[str, Any]:
+        """Get Airflow configuration."""
+        pass

--- a/src/astro_airflow_mcp/models.py
+++ b/src/astro_airflow_mcp/models.py
@@ -1,0 +1,300 @@
+"""Pydantic models for Airflow API responses."""
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DAGInfo(BaseModel):
+    """DAG information from Airflow API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    dag_id: str
+    dag_display_name: str | None = None
+    is_paused: bool = False
+    is_active: bool = True
+    is_subdag: bool = False
+    fileloc: str | None = None
+    file_token: str | None = None
+    owners: list[str] = Field(default_factory=list)
+    description: str | None = None
+    schedule_interval: str | None = None
+    timetable_summary: str | None = None
+    timetable_description: str | None = None
+    tags: list[dict[str, str]] = Field(default_factory=list)
+    max_active_runs: int | None = None
+    max_active_tasks: int | None = None
+    has_task_concurrency_limits: bool = False
+    has_import_errors: bool = False
+    next_dagrun: datetime | None = None
+    next_dagrun_create_after: datetime | None = None
+
+
+class DAGRun(BaseModel):
+    """DAG run information from Airflow API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    dag_run_id: str
+    dag_id: str
+    logical_date: datetime | None = None
+    execution_date: datetime | None = None
+    start_date: datetime | None = None
+    end_date: datetime | None = None
+    state: str | None = None
+    run_type: str | None = None
+    queued_at: datetime | None = None
+    external_trigger: bool = False
+    conf: dict[str, Any] = Field(default_factory=dict)
+    note: str | None = None
+
+
+class TaskInfo(BaseModel):
+    """Task definition information from Airflow API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    task_id: str
+    task_display_name: str | None = None
+    owner: str | None = None
+    start_date: datetime | None = None
+    end_date: datetime | None = None
+    trigger_rule: str | None = None
+    depends_on_past: bool = False
+    wait_for_downstream: bool = False
+    retries: int | None = None
+    retry_delay: float | None = None
+    retry_exponential_backoff: bool = False
+    execution_timeout: float | None = None
+    operator_name: str | None = None
+    pool: str | None = None
+    pool_slots: int = 1
+    queue: str | None = None
+    priority_weight: int | None = None
+    downstream_task_ids: list[str] = Field(default_factory=list)
+    upstream_task_ids: list[str] = Field(default_factory=list)
+
+
+class TaskInstance(BaseModel):
+    """Task instance execution information from Airflow API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    task_id: str
+    dag_id: str
+    dag_run_id: str | None = None
+    run_id: str | None = None
+    state: str | None = None
+    start_date: datetime | None = None
+    end_date: datetime | None = None
+    duration: float | None = None
+    try_number: int | None = None
+    max_tries: int | None = None
+    operator: str | None = None
+    pool: str | None = None
+    pool_slots: int = 1
+    queue: str | None = None
+    priority_weight: int | None = None
+    queued_when: datetime | None = None
+    executor_config: str | None = None
+
+
+class PoolInfo(BaseModel):
+    """Pool information from Airflow API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    slots: int = 128
+    occupied_slots: int = 0
+    running_slots: int = 0
+    queued_slots: int = 0
+    open_slots: int = 128
+    description: str | None = None
+    include_deferred: bool = False
+
+
+class VariableInfo(BaseModel):
+    """Variable information from Airflow API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    key: str
+    value: str | None = None
+    description: str | None = None
+    is_encrypted: bool = False
+
+
+class ConnectionInfo(BaseModel):
+    """Connection information from Airflow API (password excluded)."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    connection_id: str
+    conn_type: str | None = None
+    description: str | None = None
+    host: str | None = None
+    port: int | None = None
+    schema_: str | None = Field(None, alias="schema")
+    login: str | None = None
+    extra: str | None = None
+
+
+class ImportError(BaseModel):
+    """Import error information from Airflow API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    import_error_id: int | None = None
+    timestamp: datetime | None = None
+    filename: str | None = None
+    stack_trace: str | None = None
+
+
+class DAGWarning(BaseModel):
+    """DAG warning information from Airflow API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    dag_id: str | None = None
+    warning_type: str | None = None
+    message: str | None = None
+    timestamp: datetime | None = None
+
+
+class AssetInfo(BaseModel):
+    """Asset/Dataset information from Airflow API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    uri: str
+    extra: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    consuming_dags: list[dict[str, Any]] = Field(default_factory=list)
+    producing_tasks: list[dict[str, Any]] = Field(default_factory=list)
+    # Airflow 3 uses scheduled_dags instead of consuming_dags
+    scheduled_dags: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class VersionInfo(BaseModel):
+    """Airflow version information."""
+
+    model_config = ConfigDict(extra="allow")
+
+    version: str
+    git_version: str | None = None
+
+
+class ProviderInfo(BaseModel):
+    """Provider package information from Airflow API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    package_name: str
+    version: str | None = None
+    description: str | None = None
+
+
+class PluginInfo(BaseModel):
+    """Plugin information from Airflow API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str | None = None
+    hooks: list[str] = Field(default_factory=list)
+    executors: list[str] = Field(default_factory=list)
+    macros: list[Any] = Field(default_factory=list)
+    flask_blueprints: list[Any] = Field(default_factory=list)
+    appbuilder_views: list[Any] = Field(default_factory=list)
+    appbuilder_menu_items: list[Any] = Field(default_factory=list)
+
+
+# Response wrapper models for list endpoints
+class ListResponse(BaseModel):
+    """Base model for list responses with pagination metadata."""
+
+    total_entries: int = 0
+
+
+class DAGListResponse(ListResponse):
+    """Response for listing DAGs."""
+
+    dags: list[DAGInfo] = Field(default_factory=list)
+
+
+class DAGRunListResponse(ListResponse):
+    """Response for listing DAG runs."""
+
+    dag_runs: list[DAGRun] = Field(default_factory=list)
+
+
+class TaskListResponse(ListResponse):
+    """Response for listing tasks."""
+
+    tasks: list[TaskInfo] = Field(default_factory=list)
+
+
+class PoolListResponse(ListResponse):
+    """Response for listing pools."""
+
+    pools: list[PoolInfo] = Field(default_factory=list)
+
+
+class VariableListResponse(ListResponse):
+    """Response for listing variables."""
+
+    variables: list[VariableInfo] = Field(default_factory=list)
+
+
+class ConnectionListResponse(ListResponse):
+    """Response for listing connections."""
+
+    connections: list[ConnectionInfo] = Field(default_factory=list)
+
+
+class ImportErrorListResponse(ListResponse):
+    """Response for listing import errors."""
+
+    import_errors: list[ImportError] = Field(default_factory=list)
+
+
+class DAGWarningListResponse(ListResponse):
+    """Response for listing DAG warnings."""
+
+    dag_warnings: list[DAGWarning] = Field(default_factory=list)
+
+
+class AssetListResponse(ListResponse):
+    """Response for listing assets."""
+
+    assets: list[AssetInfo] = Field(default_factory=list)
+
+
+class ProviderListResponse(ListResponse):
+    """Response for listing providers."""
+
+    providers: list[ProviderInfo] = Field(default_factory=list)
+
+
+class PluginListResponse(ListResponse):
+    """Response for listing plugins."""
+
+    plugins: list[PluginInfo] = Field(default_factory=list)
+
+
+# Error response model
+class APIError(BaseModel):
+    """Error response from Airflow API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    error: str
+    operation: str | None = None
+    status: str | None = None
+    available: bool = True
+    note: str | None = None
+    alternative: str | None = None

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,343 @@
+"""Tests for Airflow API adapters."""
+
+import pytest
+
+from astro_airflow_mcp.adapters import (
+    AirflowV2Adapter,
+    AirflowV3Adapter,
+    NotFoundError,
+    create_adapter,
+    detect_version,
+)
+
+
+class TestNotFoundError:
+    """Tests for NotFoundError exception."""
+
+    def test_notfounderror_message(self):
+        """Test NotFoundError includes endpoint in message."""
+        error = NotFoundError("dagStats")
+        assert error.endpoint == "dagStats"
+        assert "dagStats" in str(error)
+
+
+class TestAirflowV2Adapter:
+    """Tests for AirflowV2Adapter."""
+
+    def test_api_base_path(self):
+        """Test V2 adapter uses /api/v1 path."""
+        adapter = AirflowV2Adapter(
+            "http://localhost:8080",
+            "2.9.0",
+            username="admin",
+            password="admin",
+        )
+        assert adapter.api_base_path == "/api/v1"
+
+    def test_setup_auth_bearer_token(self):
+        """Test auth setup with bearer token."""
+        adapter = AirflowV2Adapter(
+            "http://localhost:8080",
+            "2.9.0",
+            auth_token="test_token",
+        )
+        headers, auth = adapter._setup_auth()
+        assert headers["Authorization"] == "Bearer test_token"
+        assert auth is None
+
+    def test_setup_auth_basic(self):
+        """Test auth setup with basic auth."""
+        adapter = AirflowV2Adapter(
+            "http://localhost:8080",
+            "2.9.0",
+            username="admin",
+            password="admin",
+        )
+        headers, auth = adapter._setup_auth()
+        assert "Authorization" not in headers
+        assert auth == ("admin", "admin")
+
+    def test_setup_auth_none(self):
+        """Test auth setup with no credentials."""
+        adapter = AirflowV2Adapter(
+            "http://localhost:8080",
+            "2.9.0",
+        )
+        headers, auth = adapter._setup_auth()
+        assert headers == {}
+        assert auth is None
+
+    def test_get_dag_stats_returns_not_available(self):
+        """Test V2 adapter returns not available for dagStats."""
+        adapter = AirflowV2Adapter(
+            "http://localhost:8080",
+            "2.9.0",
+        )
+        result = adapter.get_dag_stats()
+        assert result["available"] is False
+        assert "alternative" in result
+
+    def test_list_dags_call(self, mocker):
+        """Test list_dags makes correct API call."""
+        adapter = AirflowV2Adapter(
+            "http://localhost:8080",
+            "2.9.0",
+            username="admin",
+            password="admin",
+        )
+
+        mock_response = mocker.Mock()
+        mock_response.json.return_value = {"dags": [], "total_entries": 0}
+        mock_response.status_code = 200
+        mock_response.raise_for_status = mocker.Mock()
+
+        mock_client = mocker.Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = mocker.Mock(return_value=mock_client)
+        mock_client.__exit__ = mocker.Mock(return_value=False)
+
+        mocker.patch("httpx.Client", return_value=mock_client)
+
+        result = adapter.list_dags(limit=50, offset=0)
+
+        assert result == {"dags": [], "total_entries": 0}
+        mock_client.get.assert_called_once()
+        call_args = mock_client.get.call_args
+        assert "/api/v1/dags" in call_args[0][0]
+
+    def test_list_assets_normalizes_field_names(self, mocker):
+        """Test V2 adapter normalizes datasets to assets."""
+        adapter = AirflowV2Adapter(
+            "http://localhost:8080",
+            "2.9.0",
+        )
+
+        mock_response = mocker.Mock()
+        mock_response.json.return_value = {
+            "datasets": [
+                {
+                    "id": 1,
+                    "uri": "s3://bucket/path",
+                    "consuming_dags": [{"dag_id": "consumer"}],
+                }
+            ],
+            "total_entries": 1,
+        }
+        mock_response.status_code = 200
+        mock_response.raise_for_status = mocker.Mock()
+
+        mock_client = mocker.Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = mocker.Mock(return_value=mock_client)
+        mock_client.__exit__ = mocker.Mock(return_value=False)
+
+        mocker.patch("httpx.Client", return_value=mock_client)
+
+        result = adapter.list_assets()
+
+        # Check normalization
+        assert "assets" in result
+        assert "datasets" not in result
+        assert result["assets"][0]["scheduled_dags"] == [{"dag_id": "consumer"}]
+        assert "consuming_dags" not in result["assets"][0]
+
+
+class TestAirflowV3Adapter:
+    """Tests for AirflowV3Adapter."""
+
+    def test_api_base_path(self):
+        """Test V3 adapter uses /api/v2 path."""
+        adapter = AirflowV3Adapter(
+            "http://localhost:8080",
+            "3.0.0",
+        )
+        assert adapter.api_base_path == "/api/v2"
+
+    def test_get_dag_stats_call(self, mocker):
+        """Test V3 adapter calls dagStats endpoint."""
+        adapter = AirflowV3Adapter(
+            "http://localhost:8080",
+            "3.0.0",
+        )
+
+        mock_response = mocker.Mock()
+        mock_response.json.return_value = {"dags": []}
+        mock_response.status_code = 200
+        mock_response.raise_for_status = mocker.Mock()
+
+        mock_client = mocker.Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = mocker.Mock(return_value=mock_client)
+        mock_client.__exit__ = mocker.Mock(return_value=False)
+
+        mocker.patch("httpx.Client", return_value=mock_client)
+
+        result = adapter.get_dag_stats()
+
+        assert result == {"dags": []}
+        call_args = mock_client.get.call_args
+        assert "/api/v2/dagStats" in call_args[0][0]
+
+    def test_passthrough_params(self, mocker):
+        """Test kwargs are passed through to API call."""
+        adapter = AirflowV3Adapter(
+            "http://localhost:8080",
+            "3.0.0",
+        )
+
+        mock_response = mocker.Mock()
+        mock_response.json.return_value = {"dags": []}
+        mock_response.status_code = 200
+        mock_response.raise_for_status = mocker.Mock()
+
+        mock_client = mocker.Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = mocker.Mock(return_value=mock_client)
+        mock_client.__exit__ = mocker.Mock(return_value=False)
+
+        mocker.patch("httpx.Client", return_value=mock_client)
+
+        # Pass additional filter params
+        adapter.list_dags(limit=10, offset=0, tags=["production"], only_active=True)
+
+        call_kwargs = mock_client.get.call_args[1]
+        assert call_kwargs["params"]["tags"] == ["production"]
+        assert call_kwargs["params"]["only_active"] is True
+
+
+class TestVersionDetection:
+    """Tests for version detection logic."""
+
+    def test_detect_version_v3(self, mocker):
+        """Test version detection for Airflow 3.x."""
+        mock_response = mocker.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"version": "3.0.0"}
+
+        mock_client = mocker.Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = mocker.Mock(return_value=mock_client)
+        mock_client.__exit__ = mocker.Mock(return_value=False)
+
+        mocker.patch("httpx.Client", return_value=mock_client)
+
+        major, full = detect_version("http://localhost:8080")
+
+        assert major == 3
+        assert full == "3.0.0"
+
+    def test_detect_version_v2(self, mocker):
+        """Test version detection for Airflow 2.x."""
+        # First call to /api/v2/version fails (not Airflow 3)
+        fail_response = mocker.Mock()
+        fail_response.status_code = 404
+
+        # Second call to /api/v1/version succeeds
+        success_response = mocker.Mock()
+        success_response.status_code = 200
+        success_response.json.return_value = {"version": "2.9.0"}
+
+        mock_client = mocker.Mock()
+        mock_client.get.side_effect = [fail_response, success_response]
+        mock_client.__enter__ = mocker.Mock(return_value=mock_client)
+        mock_client.__exit__ = mocker.Mock(return_value=False)
+
+        mocker.patch("httpx.Client", return_value=mock_client)
+
+        major, full = detect_version("http://localhost:8080")
+
+        assert major == 2
+        assert full == "2.9.0"
+
+
+class TestAdapterFactory:
+    """Tests for adapter factory."""
+
+    def test_create_adapter_v3(self, mocker):
+        """Test factory creates V3 adapter for Airflow 3.x."""
+        mocker.patch(
+            "astro_airflow_mcp.adapters.detect_version",
+            return_value=(3, "3.0.0"),
+        )
+
+        adapter = create_adapter("http://localhost:8080")
+
+        assert isinstance(adapter, AirflowV3Adapter)
+        assert adapter.version == "3.0.0"
+
+    def test_create_adapter_v2(self, mocker):
+        """Test factory creates V2 adapter for Airflow 2.x."""
+        mocker.patch(
+            "astro_airflow_mcp.adapters.detect_version",
+            return_value=(2, "2.9.0"),
+        )
+
+        adapter = create_adapter("http://localhost:8080")
+
+        assert isinstance(adapter, AirflowV2Adapter)
+        assert adapter.version == "2.9.0"
+
+    def test_create_adapter_v2_default_auth(self, mocker):
+        """Test factory applies default auth for Airflow 2.x."""
+        mocker.patch(
+            "astro_airflow_mcp.adapters.detect_version",
+            return_value=(2, "2.9.0"),
+        )
+
+        adapter = create_adapter("http://localhost:8080")
+
+        # V2 defaults to admin:admin if no auth provided
+        assert adapter.username == "admin"
+        assert adapter.password == "admin"
+
+    def test_create_adapter_unsupported_version(self, mocker):
+        """Test factory raises error for unsupported version."""
+        mocker.patch(
+            "astro_airflow_mcp.adapters.detect_version",
+            return_value=(1, "1.10.0"),
+        )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            create_adapter("http://localhost:8080")
+
+        assert "Unsupported Airflow version" in str(exc_info.value)
+
+
+class TestFeatureDetection:
+    """Tests for runtime feature detection."""
+
+    def test_v2_adapter_notfound_handling(self, mocker):
+        """Test V2 adapter handles 404 gracefully for missing endpoints."""
+        adapter = AirflowV2Adapter(
+            "http://localhost:8080",
+            "2.6.0",
+        )
+
+        mock_response = mocker.Mock()
+        mock_response.status_code = 404
+
+        mock_client = mocker.Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = mocker.Mock(return_value=mock_client)
+        mock_client.__exit__ = mocker.Mock(return_value=False)
+
+        mocker.patch("httpx.Client", return_value=mock_client)
+
+        # list_assets should handle 404 gracefully for old Airflow versions
+        result = adapter.list_assets()
+
+        assert result["available"] is False
+        assert "alternative" in result
+
+    def test_handle_not_found_method(self):
+        """Test _handle_not_found returns structured response."""
+        adapter = AirflowV3Adapter(
+            "http://localhost:8080",
+            "3.0.0",
+        )
+
+        result = adapter._handle_not_found("testEndpoint", alternative="Use alternative")
+
+        assert result["available"] is False
+        assert "testEndpoint" in result["note"]
+        assert result["alternative"] == "Use alternative"

--- a/tests/test_consolidated_tools.py
+++ b/tests/test_consolidated_tools.py
@@ -1,0 +1,252 @@
+"""Tests for consolidated MCP tools."""
+
+import json
+
+
+# Helper to get the underlying function from a decorated MCP tool
+def get_tool_fn(module, tool_name):
+    """Get the underlying function from an MCP tool."""
+    tool = getattr(module, tool_name)
+    # FastMCP's FunctionTool has a 'fn' attribute with the original function
+    if hasattr(tool, "fn"):
+        return tool.fn
+    return tool
+
+
+class TestExploreDag:
+    """Tests for explore_dag consolidated tool."""
+
+    def test_explore_dag_success(self, mocker):
+        """Test explore_dag returns combined data."""
+        import astro_airflow_mcp.server as server_module
+
+        mock_dag = {"dag_id": "example_dag", "is_paused": False}
+        mock_tasks = {"tasks": [{"task_id": "task1"}, {"task_id": "task2"}]}
+        mock_source = {"content": "print('hello')"}
+
+        def mock_api_call(endpoint, *args, **kwargs):
+            if "dags/example_dag/tasks" in endpoint:
+                return mock_tasks
+            elif "dagSources" in endpoint:
+                return mock_source
+            else:
+                return mock_dag
+
+        mocker.patch("astro_airflow_mcp.server._call_airflow_api", side_effect=mock_api_call)
+
+        explore_dag_fn = get_tool_fn(server_module, "explore_dag")
+        result = explore_dag_fn("example_dag")
+        data = json.loads(result)
+
+        assert data["dag_id"] == "example_dag"
+        assert data["dag_info"]["dag_id"] == "example_dag"
+        assert len(data["tasks"]) == 2
+        assert data["source"]["content"] == "print('hello')"
+
+    def test_explore_dag_partial_failure(self, mocker):
+        """Test explore_dag handles partial API failures."""
+        import astro_airflow_mcp.server as server_module
+
+        mock_dag = {"dag_id": "example_dag"}
+
+        def mock_api_call(endpoint, *args, **kwargs):
+            if "tasks" in endpoint:
+                raise Exception("Tasks endpoint failed")
+            elif "dagSources" in endpoint:
+                raise Exception("Source endpoint failed")
+            return mock_dag
+
+        mocker.patch("astro_airflow_mcp.server._call_airflow_api", side_effect=mock_api_call)
+
+        explore_dag_fn = get_tool_fn(server_module, "explore_dag")
+        result = explore_dag_fn("example_dag")
+        data = json.loads(result)
+
+        # Should still have DAG info even if tasks/source failed
+        assert data["dag_id"] == "example_dag"
+        assert "error" in data["tasks"]
+        assert "error" in data["source"]
+
+
+class TestDiagnoseDagRun:
+    """Tests for diagnose_dag_run consolidated tool."""
+
+    def test_diagnose_dag_run_success(self, mocker):
+        """Test diagnose_dag_run returns run and task info."""
+        import astro_airflow_mcp.server as server_module
+
+        mock_run = {
+            "dag_run_id": "manual__2024-01-01",
+            "state": "failed",
+        }
+        mock_task_instances = {
+            "task_instances": [
+                {"task_id": "task1", "state": "success"},
+                {"task_id": "task2", "state": "failed", "try_number": 3},
+                {"task_id": "task3", "state": "upstream_failed"},
+            ]
+        }
+
+        def mock_api_call(endpoint, *args, **kwargs):
+            if "taskInstances" in endpoint:
+                return mock_task_instances
+            return mock_run
+
+        mocker.patch("astro_airflow_mcp.server._call_airflow_api", side_effect=mock_api_call)
+
+        diagnose_fn = get_tool_fn(server_module, "diagnose_dag_run")
+        result = diagnose_fn("example_dag", "manual__2024-01-01")
+        data = json.loads(result)
+
+        assert data["dag_id"] == "example_dag"
+        assert data["dag_run_id"] == "manual__2024-01-01"
+        assert data["run_info"]["state"] == "failed"
+
+        # Check summary
+        assert data["summary"]["total_tasks"] == 3
+        assert data["summary"]["state_counts"]["success"] == 1
+        assert data["summary"]["state_counts"]["failed"] == 1
+        assert data["summary"]["state_counts"]["upstream_failed"] == 1
+        assert len(data["summary"]["failed_tasks"]) == 2
+
+    def test_diagnose_dag_run_not_found(self, mocker):
+        """Test diagnose_dag_run handles missing run."""
+        import astro_airflow_mcp.server as server_module
+
+        mocker.patch(
+            "astro_airflow_mcp.server._call_airflow_api",
+            side_effect=Exception("Run not found"),
+        )
+
+        diagnose_fn = get_tool_fn(server_module, "diagnose_dag_run")
+        result = diagnose_fn("example_dag", "nonexistent")
+        data = json.loads(result)
+
+        assert "error" in data["run_info"]
+
+
+class TestGetSystemHealth:
+    """Tests for get_system_health consolidated tool."""
+
+    def test_get_system_health_healthy(self, mocker):
+        """Test get_system_health when system is healthy."""
+        import astro_airflow_mcp.server as server_module
+
+        mock_version = {"version": "3.0.0"}
+        mock_import_errors = {"import_errors": []}
+        mock_warnings = {"dag_warnings": []}
+        mock_stats = {"dags": []}
+
+        def mock_api_call(endpoint, *args, **kwargs):
+            if "version" in endpoint:
+                return mock_version
+            elif "importErrors" in endpoint:
+                return mock_import_errors
+            elif "dagWarnings" in endpoint:
+                return mock_warnings
+            elif "dagStats" in endpoint:
+                return mock_stats
+            return {}
+
+        mocker.patch("astro_airflow_mcp.server._call_airflow_api", side_effect=mock_api_call)
+
+        health_fn = get_tool_fn(server_module, "get_system_health")
+        result = health_fn()
+        data = json.loads(result)
+
+        assert data["version"]["version"] == "3.0.0"
+        assert data["import_errors"]["count"] == 0
+        assert data["dag_warnings"]["count"] == 0
+        assert data["overall_status"] == "healthy"
+
+    def test_get_system_health_with_import_errors(self, mocker):
+        """Test get_system_health detects import errors."""
+        import astro_airflow_mcp.server as server_module
+
+        mock_version = {"version": "3.0.0"}
+        mock_import_errors = {
+            "import_errors": [{"filename": "/dags/broken.py", "stack_trace": "SyntaxError"}]
+        }
+        mock_warnings = {"dag_warnings": []}
+        mock_stats = {"dags": []}
+
+        def mock_api_call(endpoint, *args, **kwargs):
+            if "version" in endpoint:
+                return mock_version
+            elif "importErrors" in endpoint:
+                return mock_import_errors
+            elif "dagWarnings" in endpoint:
+                return mock_warnings
+            elif "dagStats" in endpoint:
+                return mock_stats
+            return {}
+
+        mocker.patch("astro_airflow_mcp.server._call_airflow_api", side_effect=mock_api_call)
+
+        health_fn = get_tool_fn(server_module, "get_system_health")
+        result = health_fn()
+        data = json.loads(result)
+
+        assert data["import_errors"]["count"] == 1
+        assert data["overall_status"] == "unhealthy"
+        assert "import error" in data["status_reason"]
+
+    def test_get_system_health_with_warnings(self, mocker):
+        """Test get_system_health detects warnings."""
+        import astro_airflow_mcp.server as server_module
+
+        mock_version = {"version": "3.0.0"}
+        mock_import_errors = {"import_errors": []}
+        mock_warnings = {
+            "dag_warnings": [{"dag_id": "deprecated_dag", "warning_type": "deprecation"}]
+        }
+        mock_stats = {"dags": []}
+
+        def mock_api_call(endpoint, *args, **kwargs):
+            if "version" in endpoint:
+                return mock_version
+            elif "importErrors" in endpoint:
+                return mock_import_errors
+            elif "dagWarnings" in endpoint:
+                return mock_warnings
+            elif "dagStats" in endpoint:
+                return mock_stats
+            return {}
+
+        mocker.patch("astro_airflow_mcp.server._call_airflow_api", side_effect=mock_api_call)
+
+        health_fn = get_tool_fn(server_module, "get_system_health")
+        result = health_fn()
+        data = json.loads(result)
+
+        assert data["dag_warnings"]["count"] == 1
+        assert data["overall_status"] == "warning"
+
+    def test_get_system_health_dag_stats_unavailable(self, mocker):
+        """Test get_system_health handles missing dagStats (Airflow 2.x)."""
+        import astro_airflow_mcp.server as server_module
+
+        mock_version = {"version": "2.9.0"}
+        mock_import_errors = {"import_errors": []}
+        mock_warnings = {"dag_warnings": []}
+
+        def mock_api_call(endpoint, *args, **kwargs):
+            if "version" in endpoint:
+                return mock_version
+            elif "importErrors" in endpoint:
+                return mock_import_errors
+            elif "dagWarnings" in endpoint:
+                return mock_warnings
+            elif "dagStats" in endpoint:
+                raise Exception("Endpoint not found")
+            return {}
+
+        mocker.patch("astro_airflow_mcp.server._call_airflow_api", side_effect=mock_api_call)
+
+        health_fn = get_tool_fn(server_module, "get_system_health")
+        result = health_fn()
+        data = json.loads(result)
+
+        assert data["dag_stats"]["available"] is False
+        # Should still report overall health
+        assert data["overall_status"] == "healthy"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,290 @@
+"""Tests for Pydantic models."""
+
+from datetime import datetime
+
+from astro_airflow_mcp.models import (
+    APIError,
+    AssetInfo,
+    ConnectionInfo,
+    DAGInfo,
+    DAGRun,
+    DAGWarning,
+    ImportError,
+    PluginInfo,
+    PoolInfo,
+    ProviderInfo,
+    TaskInfo,
+    TaskInstance,
+    VariableInfo,
+    VersionInfo,
+)
+
+
+class TestDAGInfo:
+    """Tests for DAGInfo model."""
+
+    def test_minimal_dag_info(self):
+        """Test DAGInfo with minimal fields."""
+        dag = DAGInfo(dag_id="test_dag")
+        assert dag.dag_id == "test_dag"
+        assert dag.is_paused is False
+        assert dag.is_active is True
+        assert dag.owners == []
+        assert dag.tags == []
+
+    def test_full_dag_info(self):
+        """Test DAGInfo with all fields."""
+        dag = DAGInfo(
+            dag_id="example_dag",
+            dag_display_name="Example DAG",
+            is_paused=True,
+            is_active=False,
+            is_subdag=False,
+            fileloc="/opt/airflow/dags/example.py",
+            file_token="abcd1234",
+            owners=["airflow", "admin"],
+            description="An example DAG",
+            schedule_interval="0 * * * *",
+            tags=[{"name": "production"}],
+            max_active_runs=5,
+            max_active_tasks=10,
+            has_task_concurrency_limits=True,
+            has_import_errors=False,
+        )
+        assert dag.dag_id == "example_dag"
+        assert dag.is_paused is True
+        assert dag.owners == ["airflow", "admin"]
+        assert dag.schedule_interval == "0 * * * *"
+
+    def test_dag_info_extra_fields(self):
+        """Test DAGInfo allows extra fields."""
+        dag = DAGInfo(dag_id="test", custom_field="custom_value")
+        assert dag.dag_id == "test"
+        assert dag.custom_field == "custom_value"
+
+
+class TestDAGRun:
+    """Tests for DAGRun model."""
+
+    def test_minimal_dag_run(self):
+        """Test DAGRun with minimal fields."""
+        run = DAGRun(dag_run_id="manual__2024-01-01", dag_id="test_dag")
+        assert run.dag_run_id == "manual__2024-01-01"
+        assert run.dag_id == "test_dag"
+        assert run.external_trigger is False
+
+    def test_dag_run_with_dates(self):
+        """Test DAGRun with datetime fields."""
+        now = datetime.now()
+        run = DAGRun(
+            dag_run_id="scheduled__2024-01-01",
+            dag_id="test_dag",
+            logical_date=now,
+            start_date=now,
+            state="running",
+            run_type="scheduled",
+        )
+        assert run.state == "running"
+        assert run.run_type == "scheduled"
+        assert run.logical_date == now
+
+
+class TestTaskInfo:
+    """Tests for TaskInfo model."""
+
+    def test_minimal_task_info(self):
+        """Test TaskInfo with minimal fields."""
+        task = TaskInfo(task_id="extract")
+        assert task.task_id == "extract"
+        assert task.depends_on_past is False
+        assert task.downstream_task_ids == []
+
+    def test_task_with_dependencies(self):
+        """Test TaskInfo with dependency info."""
+        task = TaskInfo(
+            task_id="transform",
+            operator_name="PythonOperator",
+            upstream_task_ids=["extract"],
+            downstream_task_ids=["load"],
+        )
+        assert task.upstream_task_ids == ["extract"]
+        assert task.downstream_task_ids == ["load"]
+
+
+class TestTaskInstance:
+    """Tests for TaskInstance model."""
+
+    def test_task_instance(self):
+        """Test TaskInstance model."""
+        ti = TaskInstance(
+            task_id="extract",
+            dag_id="etl_dag",
+            dag_run_id="manual__2024-01-01",
+            state="success",
+            try_number=1,
+            duration=10.5,
+        )
+        assert ti.task_id == "extract"
+        assert ti.state == "success"
+        assert ti.duration == 10.5
+
+
+class TestPoolInfo:
+    """Tests for PoolInfo model."""
+
+    def test_default_pool(self):
+        """Test PoolInfo with defaults."""
+        pool = PoolInfo(name="default_pool")
+        assert pool.name == "default_pool"
+        assert pool.slots == 128
+        assert pool.occupied_slots == 0
+
+    def test_custom_pool(self):
+        """Test PoolInfo with custom values."""
+        pool = PoolInfo(
+            name="limited_pool",
+            slots=5,
+            occupied_slots=3,
+            running_slots=2,
+            queued_slots=1,
+            open_slots=2,
+        )
+        assert pool.slots == 5
+        assert pool.occupied_slots == 3
+        assert pool.open_slots == 2
+
+
+class TestConnectionInfo:
+    """Tests for ConnectionInfo model."""
+
+    def test_connection_info(self):
+        """Test ConnectionInfo model."""
+        conn = ConnectionInfo(
+            connection_id="postgres_default",
+            conn_type="postgres",
+            host="localhost",
+            port=5432,
+            login="airflow",
+        )
+        assert conn.connection_id == "postgres_default"
+        assert conn.conn_type == "postgres"
+        assert conn.port == 5432
+
+    def test_connection_info_schema_alias(self):
+        """Test ConnectionInfo handles 'schema' field aliasing."""
+        conn = ConnectionInfo(
+            connection_id="test",
+            conn_type="postgres",
+            schema="public",
+        )
+        assert conn.schema_ == "public"
+
+
+class TestVariableInfo:
+    """Tests for VariableInfo model."""
+
+    def test_variable_info(self):
+        """Test VariableInfo model."""
+        var = VariableInfo(
+            key="api_endpoint",
+            value="https://api.example.com",
+            description="External API URL",
+        )
+        assert var.key == "api_endpoint"
+        assert var.value == "https://api.example.com"
+
+
+class TestAssetInfo:
+    """Tests for AssetInfo model."""
+
+    def test_asset_info(self):
+        """Test AssetInfo model."""
+        asset = AssetInfo(
+            id=1,
+            uri="s3://bucket/path/file.csv",
+            consuming_dags=[{"dag_id": "consumer_dag"}],
+            producing_tasks=[{"task_id": "producer_task"}],
+        )
+        assert asset.uri == "s3://bucket/path/file.csv"
+        assert len(asset.consuming_dags) == 1
+
+
+class TestVersionInfo:
+    """Tests for VersionInfo model."""
+
+    def test_version_info(self):
+        """Test VersionInfo model."""
+        version = VersionInfo(version="3.0.0", git_version="abc123")
+        assert version.version == "3.0.0"
+        assert version.git_version == "abc123"
+
+
+class TestProviderInfo:
+    """Tests for ProviderInfo model."""
+
+    def test_provider_info(self):
+        """Test ProviderInfo model."""
+        provider = ProviderInfo(
+            package_name="apache-airflow-providers-amazon",
+            version="8.0.0",
+            description="Amazon AWS integration",
+        )
+        assert provider.package_name == "apache-airflow-providers-amazon"
+
+
+class TestPluginInfo:
+    """Tests for PluginInfo model."""
+
+    def test_plugin_info(self):
+        """Test PluginInfo model."""
+        plugin = PluginInfo(
+            name="custom_plugin",
+            hooks=["CustomHook"],
+            executors=[],
+        )
+        assert plugin.name == "custom_plugin"
+        assert plugin.hooks == ["CustomHook"]
+
+
+class TestImportError:
+    """Tests for ImportError model."""
+
+    def test_import_error(self):
+        """Test ImportError model."""
+        error = ImportError(
+            import_error_id=1,
+            filename="/opt/airflow/dags/broken_dag.py",
+            stack_trace="SyntaxError: invalid syntax",
+        )
+        assert error.filename == "/opt/airflow/dags/broken_dag.py"
+        assert "SyntaxError" in error.stack_trace
+
+
+class TestDAGWarning:
+    """Tests for DAGWarning model."""
+
+    def test_dag_warning(self):
+        """Test DAGWarning model."""
+        warning = DAGWarning(
+            dag_id="deprecated_dag",
+            warning_type="deprecated_parameter",
+            message="Parameter X is deprecated",
+        )
+        assert warning.dag_id == "deprecated_dag"
+        assert warning.warning_type == "deprecated_parameter"
+
+
+class TestAPIError:
+    """Tests for APIError model."""
+
+    def test_api_error(self):
+        """Test APIError model for unavailable features."""
+        error = APIError(
+            error="Not found",
+            operation="get_dag_stats",
+            available=False,
+            note="dagStats not available in Airflow 2.x",
+            alternative="Use list_dag_runs instead",
+        )
+        assert error.available is False
+        assert error.alternative == "Use list_dag_runs instead"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,8 +2,8 @@
 
 import json
 
+import httpx
 import pytest
-import requests
 
 from astro_airflow_mcp.server import (
     DEFAULT_AIRFLOW_URL,
@@ -22,16 +22,23 @@ class TestCallAirflowAPI:
         mock_response = mocker.Mock()
         mock_response.json.return_value = {"dags": []}
         mock_response.raise_for_status = mocker.Mock()
-        mock_get = mocker.patch("requests.get", return_value=mock_response)
+        mock_response.status_code = 200
+
+        mock_client = mocker.Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = mocker.Mock(return_value=mock_client)
+        mock_client.__exit__ = mocker.Mock(return_value=False)
+
+        mocker.patch("httpx.Client", return_value=mock_client)
 
         result = _call_airflow_api("dags")
 
         assert result == {"dags": []}
-        mock_get.assert_called_once_with(
+        mock_client.get.assert_called_once_with(
             f"{DEFAULT_AIRFLOW_URL}/api/v2/dags",
             params=None,
             headers={},
-            timeout=30,
+            auth=None,
         )
 
     def test_api_call_with_auth_token(self, mocker):
@@ -39,28 +46,63 @@ class TestCallAirflowAPI:
         mock_response = mocker.Mock()
         mock_response.json.return_value = {"version": "3.0.0"}
         mock_response.raise_for_status = mocker.Mock()
-        mock_get = mocker.patch("requests.get", return_value=mock_response)
+        mock_response.status_code = 200
+
+        mock_client = mocker.Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = mocker.Mock(return_value=mock_client)
+        mock_client.__exit__ = mocker.Mock(return_value=False)
+
+        mocker.patch("httpx.Client", return_value=mock_client)
 
         result = _call_airflow_api("version", auth_token="test_token_123")
 
         assert result == {"version": "3.0.0"}
-        mock_get.assert_called_once()
-        call_kwargs = mock_get.call_args[1]
+        mock_client.get.assert_called_once()
+        call_kwargs = mock_client.get.call_args[1]
         assert call_kwargs["headers"]["Authorization"] == "Bearer test_token_123"
+
+    def test_api_call_with_basic_auth(self, mocker):
+        """Test API call with basic auth (username/password)."""
+        mock_response = mocker.Mock()
+        mock_response.json.return_value = {"version": "2.9.0"}
+        mock_response.raise_for_status = mocker.Mock()
+        mock_response.status_code = 200
+
+        mock_client = mocker.Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = mocker.Mock(return_value=mock_client)
+        mock_client.__exit__ = mocker.Mock(return_value=False)
+
+        mocker.patch("httpx.Client", return_value=mock_client)
+
+        result = _call_airflow_api("version", username="admin", password="admin")
+
+        assert result == {"version": "2.9.0"}
+        mock_client.get.assert_called_once()
+        call_kwargs = mock_client.get.call_args[1]
+        assert call_kwargs["auth"] == ("admin", "admin")
 
     def test_api_call_with_params(self, mocker):
         """Test API call with query parameters."""
         mock_response = mocker.Mock()
         mock_response.json.return_value = {"dags": [], "total_entries": 0}
         mock_response.raise_for_status = mocker.Mock()
-        mock_get = mocker.patch("requests.get", return_value=mock_response)
+        mock_response.status_code = 200
+
+        mock_client = mocker.Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = mocker.Mock(return_value=mock_client)
+        mock_client.__exit__ = mocker.Mock(return_value=False)
+
+        mocker.patch("httpx.Client", return_value=mock_client)
 
         params = {"limit": 50, "offset": 10}
         result = _call_airflow_api("dags", params=params)
 
         assert result == {"dags": [], "total_entries": 0}
-        mock_get.assert_called_once()
-        call_kwargs = mock_get.call_args[1]
+        mock_client.get.assert_called_once()
+        call_kwargs = mock_client.get.call_args[1]
         assert call_kwargs["params"] == params
 
     def test_api_call_with_custom_url(self, mocker):
@@ -68,39 +110,59 @@ class TestCallAirflowAPI:
         mock_response = mocker.Mock()
         mock_response.json.return_value = {"status": "ok"}
         mock_response.raise_for_status = mocker.Mock()
-        mock_get = mocker.patch("requests.get", return_value=mock_response)
+        mock_response.status_code = 200
+
+        mock_client = mocker.Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = mocker.Mock(return_value=mock_client)
+        mock_client.__exit__ = mocker.Mock(return_value=False)
+
+        mocker.patch("httpx.Client", return_value=mock_client)
 
         custom_url = "https://custom.airflow.com"
         result = _call_airflow_api("health", airflow_url=custom_url)
 
         assert result == {"status": "ok"}
-        mock_get.assert_called_once()
-        call_args = mock_get.call_args[0]
+        mock_client.get.assert_called_once()
+        call_args = mock_client.get.call_args[0]
         assert call_args[0] == f"{custom_url}/api/v2/health"
 
     def test_api_call_request_exception(self, mocker):
         """Test API call handles request exceptions."""
-        mocker.patch(
-            "requests.get",
-            side_effect=requests.exceptions.ConnectionError("Connection failed"),
-        )
+        mock_client = mocker.Mock()
+        mock_client.get.side_effect = httpx.RequestError("Connection failed")
+        mock_client.__enter__ = mocker.Mock(return_value=mock_client)
+        mock_client.__exit__ = mocker.Mock(return_value=False)
+
+        mocker.patch("httpx.Client", return_value=mock_client)
 
         with pytest.raises(Exception) as exc_info:
             _call_airflow_api("dags")
 
         assert "Error connecting to Airflow API" in str(exc_info.value)
-        assert "Connection failed" in str(exc_info.value)
 
     def test_api_call_http_error(self, mocker):
         """Test API call handles HTTP errors."""
         mock_response = mocker.Mock()
-        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("404 Not Found")
-        mocker.patch("requests.get", return_value=mock_response)
+        mock_response.status_code = 404
+        mock_response.text = "Not Found"
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "404 Not Found",
+            request=mocker.Mock(),
+            response=mock_response,
+        )
+
+        mock_client = mocker.Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = mocker.Mock(return_value=mock_client)
+        mock_client.__exit__ = mocker.Mock(return_value=False)
+
+        mocker.patch("httpx.Client", return_value=mock_client)
 
         with pytest.raises(Exception) as exc_info:
             _call_airflow_api("dags/nonexistent")
 
-        assert "Error connecting to Airflow API" in str(exc_info.value)
+        assert "HTTP error from Airflow API" in str(exc_info.value)
 
 
 class TestImplFunctions:
@@ -192,17 +254,43 @@ class TestConfiguration:
             # Restore original
             _config.auth_token = original_token
 
-    def test_configure_both(self):
-        """Test configure() updates both URL and token."""
+    def test_configure_basic_auth(self):
+        """Test configure() updates username and password."""
+        from astro_airflow_mcp.server import _config
+
+        original_username = _config.username
+        original_password = _config.password
+        try:
+            configure(username="test_user", password="test_pass")
+            assert _config.username == "test_user"
+            assert _config.password == "test_pass"
+        finally:
+            # Restore originals
+            _config.username = original_username
+            _config.password = original_password
+
+    def test_configure_all(self):
+        """Test configure() updates all settings."""
         from astro_airflow_mcp.server import _config
 
         original_url = _config.url
         original_token = _config.auth_token
+        original_username = _config.username
+        original_password = _config.password
         try:
-            configure(url="https://prod.airflow.com", auth_token="prod_token")
+            configure(
+                url="https://prod.airflow.com",
+                auth_token="prod_token",
+                username="prod_user",
+                password="prod_pass",
+            )
             assert _config.url == "https://prod.airflow.com"
             assert _config.auth_token == "prod_token"
+            assert _config.username == "prod_user"
+            assert _config.password == "prod_pass"
         finally:
             # Restore originals
             _config.url = original_url
             _config.auth_token = original_token
+            _config.username = original_username
+            _config.password = original_password


### PR DESCRIPTION
## Summary

Adds support for both Airflow 2.x and 3.x with an adapter pattern for API compatibility, plus OAuth2 authentication for Airflow 3.

## Architecture

### Request Flow

```mermaid
flowchart LR
    A[AI Agent] -->|MCP Tool Call| B[MCP Server]
    B -->|Version Detection| C{Airflow Version?}
    C -->|2.x| D[AirflowV2Adapter]
    C -->|3.x| E[AirflowV3Adapter]
    D -->|/api/v1| F[Airflow REST API]
    E -->|/api/v2| F
    F -->|JSON| B
    B -->|Structured Response| A
```

### Adapter Pattern

```mermaid
classDiagram
    class AirflowAdapter {
        <<abstract>>
        +airflow_url: str
        +version: str
        +api_base_path: str
        +list_dags()
        +get_dag()
        +list_dag_runs()
    }
    class AirflowV2Adapter {
        +api_base_path = "/api/v1"
        +list_assets() normalizes datasets
    }
    class AirflowV3Adapter {
        +api_base_path = "/api/v2"
        +_exchange_for_token()
    }
    AirflowAdapter <|-- AirflowV2Adapter
    AirflowAdapter <|-- AirflowV3Adapter
```

### Version Handling Strategy

| Version Type | Strategy |
|--------------|----------|
| Major (2.x/3.x) | Separate adapters with shared interface |
| Minor (3.1/3.2) | Runtime feature detection with graceful fallbacks |
| New API params | Pass-through `**kwargs` for forward compatibility |

### Authentication

| Airflow Version | Auth Method |
|-----------------|-------------|
| 2.x | Basic auth (defaults to admin:admin) |
| 3.x | OAuth2 token exchange via `/auth/token` |

Both support bearer token (`--auth-token`) as alternative.

---

## Relationship to #4

This PR takes a different approach than #4:

| Aspect | PR #4 | This PR |
|--------|-------|---------|
| **Client Generation** | OpenAPI spec → generated clients at build-time | Manual adapters with httpx |
| **Code Size** | +97K lines (generated) | +2.9K lines (hand-written) |
| **Maintenance** | Re-generate when API changes | Update adapter methods |

---

## Why Agent-Optimized Tools?

Per [Anthropic's MCP best practices](https://www.anthropic.com/engineering/advanced-tool-use):

> *"Design tools that map to how users think about tasks, not how your API is organized."*

**Traditional approach** (1:1 API mapping):
- Agent asks "Why did my DAG fail?"
- Agent calls `get_dag_run` → `list_task_instances` → `get_task_logs` for each failed task
- 4+ round trips, agent must understand Airflow's data model

**Agent-optimized approach** (this PR):
- Agent calls `diagnose_dag_run(dag_id, run_id)`
- Returns: run status, failed tasks, relevant logs, suggested fixes
- 1 round trip with actionable context

### Consolidated Tools

| Tool | Purpose | Replaces |
|------|---------|----------|
| `explore_dag` | Understand a DAG completely | get_dag + list_tasks + list_dag_runs + get_dag_source |
| `diagnose_dag_run` | Debug a failed run | get_dag_run + list_task_instances + get_task_logs |
| `get_system_health` | Morning health check | get_health + list_import_errors + list_dag_warnings + get_dag_stats |

---

## Ready for Claude's `defer_loading`

This MCP server is designed to work with [Claude's Tool Search Tool and `defer_loading`](https://www.anthropic.com/engineering/advanced-tool-use) feature (Nov 2025). Tool definitions marked with `defer_loading: true` are discovered on-demand rather than loaded upfront, reducing context consumption by up to 85%.

### Tool Tags for Discovery

All 23 tools are categorized with tags for efficient tool search:

| Tag | Tools | Recommended |
|-----|-------|-------------|
| `consolidated` | `explore_dag`, `diagnose_dag_run`, `get_system_health` | `defer_loading: false` (always load) |
| `dags` | `get_dag_details`, `list_dags`, `get_dag_source`, `get_dag_stats` | `defer_loading: true` |
| `tasks` | `get_task`, `list_tasks`, `get_task_instance` | `defer_loading: true` |
| `runs` | `list_dag_runs` | `defer_loading: true` |
| `monitoring` | `list_dag_warnings`, `list_import_errors`, `get_dag_stats` | `defer_loading: true` |
| `configuration` | `list_connections`, `get_variable`, `list_variables` | `defer_loading: true` |
| `resources` | `get_pool`, `list_pools` | `defer_loading: true` |
| `assets` | `list_assets` | `defer_loading: true` |
| `system` | `list_plugins`, `list_providers`, `get_airflow_version`, `get_airflow_config` | `defer_loading: true` |

### Forward-Looking: API Integration with `defer_loading`

**Note:** `defer_loading` is a beta API feature (as of Dec 2025) controlled by the MCP *client*, not the server. Claude Desktop/Claude Code do not currently expose `defer_loading` configuration. However, our tool design (tags, consolidated tools, clear descriptions) is ready for when this becomes available in Claude Desktop or for custom API integrations.

For custom agents using the Claude API directly:

```python
client.beta.messages.create(
    betas=["advanced-tool-use-2025-11-20"],
    model="claude-sonnet-4-5-20250929",
    tools=[
        {"type": "tool_search_tool_regex_20251119", "name": "tool_search_tool_regex"},
        {
            "type": "mcp_toolset",
            "mcp_server_name": "astro-airflow-mcp",
            "default_config": {"defer_loading": True},  # Defer all by default
            "configs": {
                # Keep consolidated tools always loaded
                "explore_dag": {"defer_loading": False},
                "diagnose_dag_run": {"defer_loading": False},
                "get_system_health": {"defer_loading": False},
            }
        }
    ]
)
```

When Claude needs specific capabilities (e.g., "list all pools"), it searches for "pool" and only `get_pool` and `list_pools` get loaded—not all 23 tools.

---

## New Features

### MCP Resources
Static info exposed as resources: `airflow://version`, `airflow://providers`, `airflow://plugins`, `airflow://config`

### MCP Prompts
Guided workflows: `troubleshoot_failed_dag`, `daily_health_check`, `onboard_new_dag`

---

## Contributor Guide

### Adding a new API endpoint

1. Add abstract method to `adapters/base.py`
2. Implement in `airflow_v2.py` and `airflow_v3.py`
3. Use `_handle_not_found()` if endpoint doesn't exist in a version

### Adding new parameters

Use pass-through `**kwargs` (already supported):
```python
adapter.list_dags(limit=10, tags=["production"])  # tags passed through
```

### Handling version differences

```python
# v2 - normalize response to v3 naming
def list_assets(self, ...) -> dict[str, Any]:
    data = self._call("datasets", ...)
    if "datasets" in data:
        data["assets"] = data.pop("datasets")
    return data
```

---

## Files Changed

- `src/astro_airflow_mcp/adapters/` - New adapter pattern
- `src/astro_airflow_mcp/models.py` - Pydantic models
- `src/astro_airflow_mcp/server.py` - Consolidated tools, resources, prompts
- `src/astro_airflow_mcp/__main__.py` - username/password CLI args
- `pyproject.toml` - httpx, pydantic dependencies

## Testing

- 70 unit tests covering adapters, models, consolidated tools
- Integration tested against Airflow 3.2.0

## References

- [MCP Protocol](https://modelcontextprotocol.io)
- [FastMCP](https://gofastmcp.com)
- [Anthropic Advanced Tool Use](https://www.anthropic.com/engineering/advanced-tool-use) - Tool Search Tool, defer_loading, Tool Use Examples
