### PR TITLE
Redirect logging to stderr in stdio mode

### DIFF
--- a/src/astro_airflow_mcp/__main__.py
+++ b/src/astro_airflow_mcp/__main__.py
@@ -12,10 +12,7 @@ logger = get_logger("main")
 
 def main():
     """Main entry point for the Airflow MCP server."""
-    # Configure logging
-    configure_logging(level=logging.INFO)
-
-    # Parse command line arguments
+    # Parse command line arguments first to determine transport mode
     parser = argparse.ArgumentParser(description="Airflow MCP Server")
     parser.add_argument(
         "--transport",
@@ -50,6 +47,10 @@ def main():
     )
 
     args = parser.parse_args()
+
+    # Configure logging - use stderr in stdio mode to avoid corrupting JSON-RPC
+    stdio_mode = args.transport == "stdio"
+    configure_logging(level=logging.INFO, stdio_mode=stdio_mode)
 
     # Configure Airflow connection settings
     configure(

--- a/src/astro_airflow_mcp/logging.py
+++ b/src/astro_airflow_mcp/logging.py
@@ -23,17 +23,21 @@ def get_logger(name: str | None = None) -> logging.Logger:
     return logging.getLogger("airflow_mcp")
 
 
-def configure_logging(level: str | int = logging.INFO) -> None:
+def configure_logging(level: str | int = logging.INFO, stdio_mode: bool = False) -> None:
     """Configure logging for the airflow_mcp package.
 
-    Sets up a simple console handler with a standard format.
+    Sets up a console handler with a standard format. When running in stdio mode,
+    logs are sent to stderr to avoid corrupting JSON-RPC messages on stdout.
 
     Args:
         level: Logging level (e.g., logging.INFO, logging.DEBUG, or "INFO", "DEBUG")
               Defaults to INFO.
+        stdio_mode: If True, logs to stderr instead of stdout to avoid corrupting
+                   JSON-RPC protocol messages. Defaults to False.
 
     Example:
         >>> configure_logging(level=logging.DEBUG)
+        >>> configure_logging(level=logging.INFO, stdio_mode=True)  # For MCP stdio transport
     """
     # Convert string level to int if needed
     if isinstance(level, str):
@@ -46,8 +50,9 @@ def configure_logging(level: str | int = logging.INFO) -> None:
     # Remove any existing handlers to avoid duplicates
     logger.handlers.clear()
 
-    # Create console handler
-    handler = logging.StreamHandler(sys.stdout)
+    # Create console handler - use stderr in stdio mode to avoid corrupting JSON-RPC
+    stream = sys.stderr if stdio_mode else sys.stdout
+    handler = logging.StreamHandler(stream)
     handler.setLevel(level)
 
     # Create simple formatter


### PR DESCRIPTION
## Summary
- Fixes JSON-RPC protocol corruption when running MCP server in stdio mode
- Logs were going to stdout, mixing with JSON-RPC messages and breaking go-sdk clients
- Added `stdio_mode` parameter to `configure_logging()` that redirects logs to stderr

## Test plan
- [x] Run server in stdio mode and verify stdout contains only JSON-RPC
- [x] Verify logs appear on stderr
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)