### PR TITLE
Add trigger_dag_and_wait composite MCP tool

### DIFF
--- a/src/astro_airflow_mcp/server.py
+++ b/src/astro_airflow_mcp/server.py
@@ -1329,9 +1329,8 @@ def _trigger_dag_and_wait_impl(
 
         # Check if we've reached a terminal state
         if current_state in TERMINAL_DAG_RUN_STATES:
-            # Start with full DAG run response, then add our fields
             result = {
-                **status_data,
+                "dag_run": status_data,
                 "timed_out": False,
                 "elapsed_seconds": round(time.time() - start_time, 2),
             }


### PR DESCRIPTION
## Summary
- Adds new `trigger_dag_and_wait` MCP tool that triggers a DAG and waits for completion
- Composite tool that combines `trigger_dag` + polling `get_dag_run` until terminal state
- On failure, fetches and includes failed task instance details for easier debugging

## Features
- Polls DAG run status until terminal state (`success`, `failed`, `upstream_failed`)
- Default 30-minute timeout, configurable via `timeout` parameter
- Default 5-second poll interval, configurable via `poll_interval` parameter
- Returns `elapsed_seconds` and `timed_out` status
- Includes `failed_tasks` array with task details when DAG fails

## Test plan
- [x] All existing tests pass
- [x] Linter passes
- [x] Manual testing with a real Airflow instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)