### PR TITLE
feat: Add integration tests + fix Airflow 2/3 API compatibility

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,78 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - airflow-version: "2.11.0"
+            profile: "airflow2"
+            port: "8080"
+            health-endpoint: "/health"
+          - airflow-version: "3.1.0"
+            profile: "airflow3"
+            port: "8081"
+            health-endpoint: "/api/v2/monitor/health"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+
+    - name: Install dependencies
+      run: make install-dev-ci
+
+    - name: Start Airflow ${{ matrix.airflow-version }}
+      run: docker compose -f docker-compose.test.yml --profile ${{ matrix.profile }} up -d
+
+    - name: Wait for Airflow to be ready
+      run: |
+        echo "Waiting for Airflow ${{ matrix.airflow-version }}..."
+        for i in $(seq 1 24); do  # 24 * 5s = 2 min max
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:${{ matrix.port }}${{ matrix.health-endpoint }} 2>/dev/null || echo "000")
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "Airflow is ready!"
+            exit 0
+          fi
+          echo "Waiting... ($i/24) - HTTP: $HTTP_CODE"
+          sleep 5
+        done
+        echo "Timeout waiting for Airflow"
+        exit 1
+
+    - name: Run integration tests
+      env:
+        AIRFLOW_URL: http://localhost:${{ matrix.port }}
+        AIRFLOW_USERNAME: admin
+        AIRFLOW_PASSWORD: admin
+      run: uv run pytest tests/integration/ -v --tb=short -x
+
+    - name: Show container logs on failure
+      if: failure()
+      run: |
+        echo "=== Container Status ==="
+        docker compose -f docker-compose.test.yml ps -a
+        echo ""
+        echo "=== Airflow Container Logs ==="
+        docker logs astro-airflow-mcp-${{ matrix.profile }}-1 2>&1 | tail -100
+
+    - name: Cleanup
+      if: always()
+      run: docker compose -f docker-compose.test.yml --profile ${{ matrix.profile }} down

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,96 @@
+# Docker Compose for running integration tests against multiple Airflow versions
+#
+# Usage:
+#   # Start Airflow 2.x
+#   docker compose -f docker-compose.test.yml --profile airflow2 up -d
+#   ./scripts/run-integration-tests.sh http://localhost:8080
+#
+#   # Start Airflow 3.x
+#   docker compose -f docker-compose.test.yml --profile airflow3 up -d
+#   ./scripts/run-integration-tests.sh http://localhost:8081
+#
+#   # Start both (for comprehensive testing)
+#   docker compose -f docker-compose.test.yml --profile all up -d
+
+services:
+  # PostgreSQL for Airflow 2.x (LocalExecutor requires non-SQLite DB in 2.11+)
+  postgres2:
+    image: postgres:15
+    profiles: ["airflow2", "all"]
+    environment:
+      POSTGRES_USER: airflow
+      POSTGRES_PASSWORD: airflow
+      POSTGRES_DB: airflow
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "airflow"]
+      interval: 5s
+      retries: 5
+
+  # Airflow 2.x (latest 2.x release)
+  airflow2:
+    image: apache/airflow:2.11.0-python3.11
+    profiles: ["airflow2", "all"]
+    depends_on:
+      postgres2:
+        condition: service_healthy
+    environment:
+      AIRFLOW__CORE__EXECUTOR: LocalExecutor
+      AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres2/airflow
+      AIRFLOW__CORE__LOAD_EXAMPLES: "true"
+      AIRFLOW__API__AUTH_BACKENDS: airflow.api.auth.backend.basic_auth
+      AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "true"
+      _AIRFLOW_DB_MIGRATE: "true"
+      _AIRFLOW_WWW_USER_CREATE: "true"
+      _AIRFLOW_WWW_USER_USERNAME: admin
+      _AIRFLOW_WWW_USER_PASSWORD: admin
+    ports:
+      - "8080:8080"
+    command: standalone
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
+  # PostgreSQL for Airflow 3.x
+  postgres3:
+    image: postgres:15
+    profiles: ["airflow3", "all"]
+    environment:
+      POSTGRES_USER: airflow
+      POSTGRES_PASSWORD: airflow
+      POSTGRES_DB: airflow
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "airflow"]
+      interval: 5s
+      retries: 5
+
+  # Airflow 3.x (latest 3.x release)
+  airflow3:
+    image: apache/airflow:3.1.0-python3.12
+    profiles: ["airflow3", "all"]
+    depends_on:
+      postgres3:
+        condition: service_healthy
+    environment:
+      AIRFLOW__CORE__EXECUTOR: LocalExecutor
+      AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres3/airflow
+      AIRFLOW__CORE__LOAD_EXAMPLES: "true"
+      AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "true"
+      # Use passwords file to set fixed passwords (admin:admin)
+      # See: https://github.com/apache/airflow/blob/main/dev/breeze/src/airflow_breeze/files/simple_auth_manager_passwords.json
+      AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_PASSWORDS_FILE: /opt/airflow/passwords.json
+      _AIRFLOW_DB_MIGRATE: "true"
+    ports:
+      - "8081:8080"
+    volumes:
+      - ./tests/integration/passwords.json:/tmp/passwords.json:ro
+    command: >
+      bash -c "cp /tmp/passwords.json /opt/airflow/passwords.json && airflow standalone"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/api/v2/monitor/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Run integration tests locally against a running Airflow instance
+#
+# Usage:
+#   ./scripts/run-integration-tests.sh [airflow_url] [username] [password]
+#
+# Examples:
+#   # Airflow 2.x (default admin:admin)
+#   ./scripts/run-integration-tests.sh http://localhost:8080
+#
+#   # Airflow 3.x (default admin:admin)
+#   ./scripts/run-integration-tests.sh http://localhost:8081
+#
+#   # Custom credentials
+#   ./scripts/run-integration-tests.sh http://localhost:8080 myuser mypass
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+AIRFLOW_URL="${1:-${AIRFLOW_URL:-http://localhost:8080}}"
+AIRFLOW_USERNAME="${2:-${AIRFLOW_USERNAME:-admin}}"
+AIRFLOW_PASSWORD="${3:-${AIRFLOW_PASSWORD:-admin}}"
+
+echo -e "${YELLOW}Integration Test Runner${NC}"
+echo "========================"
+echo "Airflow URL: $AIRFLOW_URL"
+echo "Username: $AIRFLOW_USERNAME"
+echo ""
+
+# Check if Airflow is reachable (try both health endpoints)
+echo -e "${YELLOW}Checking Airflow connectivity...${NC}"
+if curl -sf "$AIRFLOW_URL/health" > /dev/null 2>&1; then
+    echo -e "${GREEN}✓ Airflow is reachable${NC}"
+elif curl -sf "$AIRFLOW_URL/api/v2/monitor/health" > /dev/null 2>&1; then
+    echo -e "${GREEN}✓ Airflow is reachable${NC}"
+else
+    echo -e "${RED}✗ Cannot reach Airflow at $AIRFLOW_URL${NC}"
+    exit 1
+fi
+
+# Detect Airflow version
+echo -e "${YELLOW}Detecting Airflow version...${NC}"
+
+# Try v2 API first (Airflow 3.x)
+VERSION_RESPONSE=$(curl -sf "$AIRFLOW_URL/api/v2/version" 2>/dev/null || echo "")
+if [ -n "$VERSION_RESPONSE" ]; then
+    VERSION=$(echo "$VERSION_RESPONSE" | python3 -c "import sys, json; print(json.load(sys.stdin).get('version', 'unknown'))")
+    echo -e "${GREEN}✓ Detected Airflow 3.x: $VERSION${NC}"
+else
+    # Try v1 API (Airflow 2.x)
+    VERSION_RESPONSE=$(curl -sf -u "$AIRFLOW_USERNAME:$AIRFLOW_PASSWORD" "$AIRFLOW_URL/api/v1/version" 2>/dev/null || echo "")
+    if [ -n "$VERSION_RESPONSE" ]; then
+        VERSION=$(echo "$VERSION_RESPONSE" | python3 -c "import sys, json; print(json.load(sys.stdin).get('version', 'unknown'))")
+        echo -e "${GREEN}✓ Detected Airflow 2.x: $VERSION${NC}"
+    else
+        echo -e "${RED}✗ Could not detect Airflow version${NC}"
+        exit 1
+    fi
+fi
+
+export AIRFLOW_URL
+export AIRFLOW_USERNAME
+export AIRFLOW_PASSWORD
+
+echo ""
+echo -e "${YELLOW}Running integration tests...${NC}"
+echo ""
+
+uv run pytest tests/integration/ -v --tb=short
+
+echo ""
+echo -e "${GREEN}✓ Integration tests completed${NC}"

--- a/src/astro_airflow_mcp/server.py
+++ b/src/astro_airflow_mcp/server.py
@@ -592,29 +592,33 @@ def get_dag_source(dag_id: str) -> str:
     return _get_dag_source_impl(dag_id=dag_id)
 
 
-def _get_dag_stats_impl() -> str:
+def _get_dag_stats_impl(dag_ids: list[str] | None = None) -> str:
     """Internal implementation for getting DAG statistics from Airflow.
+
+    Args:
+        dag_ids: Optional list of DAG IDs to get stats for. If None, gets stats for all DAGs.
 
     Returns:
         JSON string containing DAG run statistics by state
     """
     try:
         adapter = _get_adapter()
-        stats_data = adapter.get_dag_stats()
+        stats_data = adapter.get_dag_stats(dag_ids=dag_ids)
         return json.dumps(stats_data, indent=2)
     except Exception as e:
         return str(e)
 
 
 @mcp.tool()
-def get_dag_stats() -> str:
-    """Get statistics about DAG runs across all DAGs (success/failure counts by state).
+def get_dag_stats(dag_ids: list[str] | None = None) -> str:
+    """Get statistics about DAG runs (success/failure counts by state).
 
     Use this tool when the user asks about:
     - "What's the overall health of my DAGs?" or "Show me DAG statistics"
     - "How many DAG runs succeeded/failed?" or "What's the success rate?"
     - "Give me a summary of DAG run states"
     - "How many runs are currently running/queued?"
+    - "Show me stats for specific DAGs"
 
     Returns statistics showing counts of DAG runs grouped by state:
     - success: Number of successful runs
@@ -623,10 +627,13 @@ def get_dag_stats() -> str:
     - queued: Number of queued runs
     - And other possible states
 
+    Args:
+        dag_ids: Optional list of DAG IDs to filter by. If not provided, returns stats for all DAGs.
+
     Returns:
         JSON with DAG run statistics organized by DAG and state
     """
-    return _get_dag_stats_impl()
+    return _get_dag_stats_impl(dag_ids=dag_ids)
 
 
 def _list_dag_warnings_impl(

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,5 @@
+"""Integration tests for Airflow MCP Server.
+
+These tests run against real Airflow instances (2.x and 3.x) to validate
+that the MCP server correctly handles API differences between versions.
+"""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,47 @@
+"""Pytest fixtures for integration tests."""
+
+import os
+
+import pytest
+
+# Skip integration tests if AIRFLOW_URL is not set
+pytestmark = pytest.mark.skipif(
+    os.getenv("AIRFLOW_URL") is None,
+    reason="Integration tests require AIRFLOW_URL environment variable",
+)
+
+
+@pytest.fixture
+def airflow_url() -> str:
+    """Get Airflow URL from environment."""
+    return os.getenv("AIRFLOW_URL", "http://localhost:8080")
+
+
+@pytest.fixture
+def airflow_username() -> str:
+    """Get Airflow username from environment."""
+    return os.getenv("AIRFLOW_USERNAME", "admin")
+
+
+@pytest.fixture
+def airflow_password() -> str:
+    """Get Airflow password from environment."""
+    return os.getenv("AIRFLOW_PASSWORD", "admin")
+
+
+@pytest.fixture
+def airflow_version() -> str:
+    """Get expected Airflow version from environment."""
+    return os.getenv("AIRFLOW_VERSION", "")
+
+
+@pytest.fixture
+def airflow_api_path() -> str:
+    """Get API path based on version."""
+    return os.getenv("AIRFLOW_API_PATH", "/api/v1")
+
+
+@pytest.fixture
+def airflow_auth_method() -> str:
+    """Get auth method (basic or oauth2)."""
+    return os.getenv("AIRFLOW_AUTH_METHOD", "basic")

--- a/tests/integration/passwords.json
+++ b/tests/integration/passwords.json
@@ -1,0 +1,1 @@
+{"admin": "admin"}

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -1,0 +1,238 @@
+"""Integration tests for all API endpoints against real Airflow instances.
+
+These tests validate that each adapter method works correctly with both
+Airflow 2.x and 3.x. They run in CI against real Airflow containers.
+"""
+
+import pytest
+
+from astro_airflow_mcp.adapters import create_adapter, detect_version
+
+
+class TestVersionDetection:
+    """Test version detection against real Airflow."""
+
+    def test_detect_version(self, airflow_url: str, airflow_username: str, airflow_password: str):
+        """Should correctly detect Airflow version."""
+        major, version = detect_version(
+            airflow_url,
+            basic_auth_getter=lambda: (airflow_username, airflow_password),
+        )
+        assert major in (2, 3), f"Expected major version 2 or 3, got {major}"
+        assert version, "Version string should not be empty"
+        print(f"Detected Airflow {version} (major: {major})")
+
+
+class TestAdapterCreation:
+    """Test adapter creation against real Airflow."""
+
+    def test_create_adapter(self, airflow_url: str, airflow_username: str, airflow_password: str):
+        """Should create appropriate adapter for detected version."""
+        adapter = create_adapter(
+            airflow_url,
+            basic_auth_getter=lambda: (airflow_username, airflow_password),
+        )
+        assert adapter is not None
+        assert adapter.version
+        print(f"Created adapter for Airflow {adapter.version}")
+
+
+class TestDAGEndpoints:
+    """Test DAG-related endpoints."""
+
+    @pytest.fixture
+    def adapter(self, airflow_url: str, airflow_username: str, airflow_password: str):
+        """Create adapter for tests."""
+        return create_adapter(
+            airflow_url,
+            basic_auth_getter=lambda: (airflow_username, airflow_password),
+        )
+
+    def test_list_dags(self, adapter):
+        """Should list DAGs successfully."""
+        result = adapter.list_dags(limit=10)
+        assert "dags" in result
+        assert isinstance(result["dags"], list)
+        print(f"Found {len(result['dags'])} DAGs")
+
+    def test_get_dag(self, adapter):
+        """Should get a specific DAG if example DAGs are loaded."""
+        # First list DAGs to find one
+        dags = adapter.list_dags(limit=1)
+        if dags.get("dags"):
+            dag_id = dags["dags"][0]["dag_id"]
+            result = adapter.get_dag(dag_id)
+            assert result.get("dag_id") == dag_id
+            print(f"Got DAG: {dag_id}")
+        else:
+            pytest.skip("No DAGs available to test")
+
+    def test_list_tasks(self, adapter):
+        """Should list tasks for a DAG."""
+        dags = adapter.list_dags(limit=1)
+        if dags.get("dags"):
+            dag_id = dags["dags"][0]["dag_id"]
+            result = adapter.list_tasks(dag_id)
+            assert "tasks" in result
+            print(f"DAG {dag_id} has {len(result['tasks'])} tasks")
+        else:
+            pytest.skip("No DAGs available to test")
+
+
+class TestDAGStatsEndpoint:
+    """Test DAG stats endpoint - the endpoint that caught us with version differences."""
+
+    @pytest.fixture
+    def adapter(self, airflow_url: str, airflow_username: str, airflow_password: str):
+        """Create adapter for tests."""
+        return create_adapter(
+            airflow_url,
+            basic_auth_getter=lambda: (airflow_username, airflow_password),
+        )
+
+    def test_get_dag_stats_with_dag_ids(self, adapter):
+        """Should get stats for specific DAGs."""
+        # First get a DAG ID
+        dags = adapter.list_dags(limit=1)
+        if dags.get("dags"):
+            dag_id = dags["dags"][0]["dag_id"]
+            result = adapter.get_dag_stats(dag_ids=[dag_id])
+
+            # Should not return an error
+            assert "error" not in result or "available" not in result
+            print(f"Got stats for DAG {dag_id}: {result}")
+        else:
+            pytest.skip("No DAGs available to test")
+
+    def test_get_dag_stats_without_dag_ids(self, adapter):
+        """Should get stats for all DAGs when no dag_ids provided.
+
+        This is the critical test - Airflow 2.x requires dag_ids,
+        but our adapter should handle this transparently.
+        """
+        result = adapter.get_dag_stats(dag_ids=None)
+
+        # Should not return an error
+        assert "error" not in result or "available" not in result
+        print(f"Got stats for all DAGs: {len(result.get('dags', []))} entries")
+
+
+class TestMonitoringEndpoints:
+    """Test monitoring endpoints."""
+
+    @pytest.fixture
+    def adapter(self, airflow_url: str, airflow_username: str, airflow_password: str):
+        """Create adapter for tests."""
+        return create_adapter(
+            airflow_url,
+            basic_auth_getter=lambda: (airflow_username, airflow_password),
+        )
+
+    def test_list_import_errors(self, adapter):
+        """Should list import errors."""
+        result = adapter.list_import_errors(limit=10)
+        assert "import_errors" in result
+        print(f"Found {len(result['import_errors'])} import errors")
+
+    def test_list_dag_warnings(self, adapter):
+        """Should list DAG warnings."""
+        result = adapter.list_dag_warnings(limit=10)
+        assert "dag_warnings" in result
+        print(f"Found {len(result['dag_warnings'])} DAG warnings")
+
+    def test_get_version(self, adapter):
+        """Should get Airflow version."""
+        result = adapter.get_version()
+        assert "version" in result
+        print(f"Airflow version: {result['version']}")
+
+
+class TestResourceEndpoints:
+    """Test resource endpoints (pools, connections, variables)."""
+
+    @pytest.fixture
+    def adapter(self, airflow_url: str, airflow_username: str, airflow_password: str):
+        """Create adapter for tests."""
+        return create_adapter(
+            airflow_url,
+            basic_auth_getter=lambda: (airflow_username, airflow_password),
+        )
+
+    def test_list_pools(self, adapter):
+        """Should list pools."""
+        result = adapter.list_pools(limit=10)
+        assert "pools" in result
+        # Default pool should always exist
+        pool_names = [p["name"] for p in result["pools"]]
+        assert "default_pool" in pool_names
+        print(f"Found {len(result['pools'])} pools")
+
+    def test_get_pool(self, adapter):
+        """Should get specific pool."""
+        result = adapter.get_pool("default_pool")
+        assert result.get("name") == "default_pool"
+        print(f"Got pool: {result}")
+
+    def test_list_variables(self, adapter):
+        """Should list variables."""
+        result = adapter.list_variables(limit=10)
+        assert "variables" in result
+        print(f"Found {len(result['variables'])} variables")
+
+    def test_list_connections(self, adapter):
+        """Should list connections (with passwords filtered)."""
+        result = adapter.list_connections(limit=10)
+        assert "connections" in result
+
+        # Verify passwords are filtered
+        for conn in result.get("connections", []):
+            if "password" in conn:
+                assert conn["password"] in (
+                    None,
+                    "",
+                    "***FILTERED***",  # noqa: S105
+                ), f"Password not filtered for {conn.get('connection_id')}"
+        print(f"Found {len(result['connections'])} connections")
+
+
+class TestAssetEndpoints:
+    """Test asset/dataset endpoints."""
+
+    @pytest.fixture
+    def adapter(self, airflow_url: str, airflow_username: str, airflow_password: str):
+        """Create adapter for tests."""
+        return create_adapter(
+            airflow_url,
+            basic_auth_getter=lambda: (airflow_username, airflow_password),
+        )
+
+    def test_list_assets(self, adapter):
+        """Should list assets (normalized from datasets in v2)."""
+        result = adapter.list_assets(limit=10)
+        # Response should have 'assets' key (normalized from 'datasets' in v2)
+        assert "assets" in result or "available" in result
+        print(f"Assets response: {result}")
+
+
+class TestProviderEndpoints:
+    """Test provider/plugin endpoints."""
+
+    @pytest.fixture
+    def adapter(self, airflow_url: str, airflow_username: str, airflow_password: str):
+        """Create adapter for tests."""
+        return create_adapter(
+            airflow_url,
+            basic_auth_getter=lambda: (airflow_username, airflow_password),
+        )
+
+    def test_list_providers(self, adapter):
+        """Should list providers."""
+        result = adapter.list_providers()
+        assert "providers" in result
+        print(f"Found {len(result['providers'])} providers")
+
+    def test_list_plugins(self, adapter):
+        """Should list plugins."""
+        result = adapter.list_plugins(limit=10)
+        assert "plugins" in result
+        print(f"Found {len(result['plugins'])} plugins")


### PR DESCRIPTION
## Summary

This PR adds comprehensive integration testing infrastructure and fixes critical Airflow 2.x and 3.x API compatibility issues discovered during testing.

## Key Fixes

### OAuth2 Token Exchange for Airflow 3.x
- Fixed token exchange to handle HTTP 201 status code (Airflow 3 returns 201, not 200)
- `AirflowV3Adapter` now auto-exchanges basic auth credentials for JWT token at init time
- Token is used for all subsequent API calls to `/api/v2/*` endpoints

### Airflow 2.x dagStats Endpoint
- Fixed: The `dagStats` endpoint in Airflow 2.x requires the `dag_ids` parameter (unlike 3.x)
- Adapter now auto-fetches all DAG IDs when none provided
- Added `dag_ids` parameter to `get_dag_stats` MCP tool for explicit filtering

## Integration Testing Infrastructure

| Component | Description |
|-----------|-------------|
| `docker-compose.test.yml` | Spins up Airflow 2.11 and 3.1 containers with PostgreSQL |
| `tests/integration/` | 17 endpoint tests covering DAGs, pools, variables, etc. |
| `.github/workflows/integration-test.yml` | CI workflow running tests against both versions |
| `scripts/run-integration-tests.sh` | Local testing script |
| `Makefile` targets | `test-integration-v2`, `test-integration-v3`, `test-all` |

## Version-Specific Behavior

| Aspect | Airflow 2.x | Airflow 3.x |
|--------|-------------|-------------|
| **API Path** | `/api/v1` | `/api/v2` |
| **Auth** | Basic Auth | JWT via OAuth2 |
| **dagStats** | Requires `dag_ids` param | Optional `dag_ids` |
| **Token Endpoint** | N/A | `/auth/token` returns 201 |

## Test Results

- **Airflow 2.11.0**: ✅ All 17 integration tests pass
- **Airflow 3.1.0**: ✅ All 17 integration tests pass  
- **Unit tests**: ✅ All 93 tests pass

## How to Test Locally

```bash
# Start Airflow 2.x and run tests
make test-integration-v2

# Start Airflow 3.x and run tests
make test-integration-v3

# Run both
make test-all
```

## Related

Addresses version-specific API issues identified in #4