### PR TITLE
Fix adapter bypass and JSON parse issues for Airflow 2.x

### DIFF
--- a/src/astro_airflow_mcp/adapters/airflow_v3.py
+++ b/src/astro_airflow_mcp/adapters/airflow_v3.py
@@ -116,6 +116,25 @@ class AirflowV3Adapter(AirflowAdapter):
         """Get details of a specific DAG run."""
         return self._call(f"dags/{dag_id}/dagRuns/{dag_run_id}")
 
+    def trigger_dag_run(
+        self, dag_id: str, logical_date: str | None = None, conf: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Trigger a new DAG run.
+
+        Args:
+            dag_id: The ID of the DAG to trigger
+            logical_date: Optional logical date for the run (can be null in Airflow 3)
+            conf: Optional configuration dictionary to pass to the DAG run
+
+        Returns:
+            Details of the triggered DAG run
+        """
+        json_body: dict[str, Any] = {"logical_date": logical_date}
+        if conf:
+            json_body["conf"] = conf
+
+        return self._post(f"dags/{dag_id}/dagRuns", json_data=json_body)
+
     def list_tasks(self, dag_id: str) -> dict[str, Any]:
         """List all tasks in a DAG."""
         return self._call(f"dags/{dag_id}/tasks")


### PR DESCRIPTION
## Summary

This PR fixes two issues with the MCP tools:

1. **Refactored consolidated tools to use adapter pattern** - Several tools were bypassing the adapter and calling APIs directly, which broke Airflow 2.x compatibility
2. **Fixed JSON parsing errors for Airflow 2.x** - Added `Accept: application/json` header to ensure endpoints return JSON instead of `text/plain`

## Changes

### Adapter Enhancements (`adapters/base.py`, `adapters/airflow_v2.py`, `adapters/airflow_v3.py`)

- Added `_post()` method to base adapter for POST requests
- Added `Accept: application/json` header to both `_call()` and `_post()` methods
- Added `trigger_dag_run()` abstract method and implementations for both v2/v3
- Added `get_task_instances()` abstract method and implementations for both v2/v3

### Server Refactoring (`server.py`)

Refactored 5 functions to use adapter methods instead of direct API calls:

| Function | Before | After |
|----------|--------|-------|
| `explore_dag()` | 3 direct `_call_airflow_api()` calls | Uses `adapter.get_dag()`, `list_tasks()`, `get_dag_source()` |
| `diagnose_dag_run()` | 2 direct `_call_airflow_api()` calls | Uses `adapter.get_dag_run()`, `get_task_instances()` |
| `get_system_health()` | 4 direct `_call_airflow_api()` calls | Uses `adapter.get_version()`, `list_import_errors()`, `list_dag_warnings()`, `get_dag_stats()` |
| `_trigger_dag_impl()` | 1 direct `_post_airflow_api()` call | Uses `adapter.trigger_dag_run()` |
| `_get_failed_task_instances()` | 1 direct `_call_airflow_api()` call | Uses `adapter.get_task_instances()` |

### Test Updates (`tests/test_consolidated_tools.py`)

- Updated tests to mock `_get_adapter()` instead of `_call_airflow_api()`

## Test plan

- [x] All 110 existing tests pass
- [x] Manual testing with Airflow 2.x instance for `get_dag_source` and `get_task_logs`
- [x] Manual testing with Airflow 3.x instance to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)