### PR TITLE
feat: Add pause_dag and unpause_dag tools for DAG management

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for Ap
 
 - **Airflow 2.x and 3.x Support**: Automatic version detection with adapter pattern
 - **MCP Tools** for accessing Airflow data:
-  - DAG management (list, get details, get source code, stats, warnings, import errors, trigger runs)
+  - DAG management (list, get details, get source code, stats, warnings, import errors, trigger, pause/unpause)
   - Task management (list, get details, get task instances, get logs)
   - Pool management (list, get details)
   - Variable management (list, get specific variables)
@@ -183,6 +183,8 @@ Configure in Cursor's MCP settings:
 | `list_dag_runs` | Get DAG run history |
 | `get_dag_run` | Get specific DAG run details |
 | `trigger_dag` | Trigger a new DAG run (start a workflow execution) |
+| `pause_dag` | Pause a DAG to prevent new scheduled runs |
+| `unpause_dag` | Unpause a DAG to resume scheduled runs |
 | `list_tasks` | Get all tasks in a DAG |
 | `get_task` | Get details about a specific task |
 | `get_task_instance` | Get task instance execution details |

--- a/src/astro_airflow_mcp/adapters/airflow_v2.py
+++ b/src/astro_airflow_mcp/adapters/airflow_v2.py
@@ -35,6 +35,28 @@ class AirflowV2Adapter(AirflowAdapter):
         # Get source using file_token
         return self._call(f"dagSources/{file_token}")
 
+    def pause_dag(self, dag_id: str) -> dict[str, Any]:
+        """Pause a DAG to prevent new runs from being scheduled.
+
+        Args:
+            dag_id: The ID of the DAG to pause
+
+        Returns:
+            Updated DAG details with is_paused=True
+        """
+        return self._patch(f"dags/{dag_id}", json_data={"is_paused": True})
+
+    def unpause_dag(self, dag_id: str) -> dict[str, Any]:
+        """Unpause a DAG to allow new runs to be scheduled.
+
+        Args:
+            dag_id: The ID of the DAG to unpause
+
+        Returns:
+            Updated DAG details with is_paused=False
+        """
+        return self._patch(f"dags/{dag_id}", json_data={"is_paused": False})
+
     def list_dag_runs(
         self, dag_id: str | None = None, limit: int = 100, offset: int = 0, **kwargs: Any
     ) -> dict[str, Any]:

--- a/src/astro_airflow_mcp/adapters/airflow_v3.py
+++ b/src/astro_airflow_mcp/adapters/airflow_v3.py
@@ -94,6 +94,28 @@ class AirflowV3Adapter(AirflowAdapter):
         """
         return self._call(f"dagSources/{dag_id}")
 
+    def pause_dag(self, dag_id: str) -> dict[str, Any]:
+        """Pause a DAG to prevent new runs from being scheduled.
+
+        Args:
+            dag_id: The ID of the DAG to pause
+
+        Returns:
+            Updated DAG details with is_paused=True
+        """
+        return self._patch(f"dags/{dag_id}", json_data={"is_paused": True})
+
+    def unpause_dag(self, dag_id: str) -> dict[str, Any]:
+        """Unpause a DAG to allow new runs to be scheduled.
+
+        Args:
+            dag_id: The ID of the DAG to unpause
+
+        Returns:
+            Updated DAG details with is_paused=False
+        """
+        return self._patch(f"dags/{dag_id}", json_data={"is_paused": False})
+
     def list_dag_runs(
         self, dag_id: str | None = None, limit: int = 100, offset: int = 0, **kwargs: Any
     ) -> dict[str, Any]:

--- a/src/astro_airflow_mcp/server.py
+++ b/src/astro_airflow_mcp/server.py
@@ -1355,6 +1355,93 @@ def trigger_dag_and_wait(
     )
 
 
+def _pause_dag_impl(dag_id: str) -> str:
+    """Internal implementation for pausing a DAG.
+
+    Args:
+        dag_id: The ID of the DAG to pause
+
+    Returns:
+        JSON string containing the updated DAG details
+    """
+    try:
+        adapter = _get_adapter()
+        data = adapter.pause_dag(dag_id)
+        return json.dumps(data, indent=2)
+    except Exception as e:
+        return str(e)
+
+
+@mcp.tool()
+def pause_dag(dag_id: str) -> str:
+    """Pause a DAG to prevent new scheduled runs from starting.
+
+    Use this tool when the user asks to:
+    - "Pause DAG X" or "Stop DAG Y from running"
+    - "Disable DAG Z" or "Prevent new runs of DAG X"
+    - "Turn off DAG scheduling" or "Suspend DAG execution"
+
+    When a DAG is paused:
+    - No new scheduled runs will be created
+    - Currently running tasks will complete
+    - Manual triggers are still possible
+    - The DAG remains visible in the UI with a paused indicator
+
+    IMPORTANT: This is a write operation that modifies Airflow state.
+    The DAG will remain paused until explicitly unpaused.
+
+    Args:
+        dag_id: The ID of the DAG to pause (e.g., "example_dag")
+
+    Returns:
+        JSON with updated DAG details showing is_paused=True
+    """
+    return _pause_dag_impl(dag_id=dag_id)
+
+
+def _unpause_dag_impl(dag_id: str) -> str:
+    """Internal implementation for unpausing a DAG.
+
+    Args:
+        dag_id: The ID of the DAG to unpause
+
+    Returns:
+        JSON string containing the updated DAG details
+    """
+    try:
+        adapter = _get_adapter()
+        data = adapter.unpause_dag(dag_id)
+        return json.dumps(data, indent=2)
+    except Exception as e:
+        return str(e)
+
+
+@mcp.tool()
+def unpause_dag(dag_id: str) -> str:
+    """Unpause a DAG to allow scheduled runs to resume.
+
+    Use this tool when the user asks to:
+    - "Unpause DAG X" or "Resume DAG Y"
+    - "Enable DAG Z" or "Start DAG scheduling again"
+    - "Turn on DAG X" or "Activate DAG Y"
+
+    When a DAG is unpaused:
+    - The scheduler will create new runs based on the schedule
+    - Any missed runs (depending on catchup setting) may be created
+    - The DAG will appear active in the UI
+
+    IMPORTANT: This is a write operation that modifies Airflow state.
+    New DAG runs will be scheduled according to the DAG's schedule_interval.
+
+    Args:
+        dag_id: The ID of the DAG to unpause (e.g., "example_dag")
+
+    Returns:
+        JSON with updated DAG details showing is_paused=False
+    """
+    return _unpause_dag_impl(dag_id=dag_id)
+
+
 def _list_assets_impl(
     limit: int = DEFAULT_LIMIT,
     offset: int = DEFAULT_OFFSET,


### PR DESCRIPTION
## Motivation

I'm building an AI-assisted development workflow where an agent helps me test DAGs in my local environment. By default, when spinning up Airflow via `astro dev start`, all DAGs are paused - this is intentional since I don't want to run any DAGs automatically, only the ones I'm actively adjusting or testing.

The current workflow requires me to manually unpause DAGs before testing and pause them again after. I want to delegate this to an AI agent, but the MCP server currently lacks the ability to pause/unpause DAGs. This PR adds that capability, enabling a fully automated test workflow:

1. Agent makes changes to DAG code
2. Agent unpauses the specific DAG via MCP
3. Agent triggers the DAG and monitors results
4. Agent pauses the DAG when done

## Summary
- Add `pause_dag(dag_id)` tool to pause a DAG and prevent new scheduled runs
- Add `unpause_dag(dag_id)` tool to resume DAG scheduling

## Changes
- New `_patch()` HTTP method in base adapter for PATCH requests
- Abstract methods in base adapter with implementations for both Airflow 2.x and 3.x
- MCP tool definitions with detailed docstrings for AI agent usage
- Unit tests for `_patch` method and pause/unpause operations
- Integration tests for both Airflow versions
- Updated README with new tools documentation

## Test plan
- [x] Unit tests pass (`make test` - 100 tests)
- [x] Lint checks pass (`ruff check`)
- [x] Pre-commit hooks pass
- [x] Integration tests against Airflow 2.x (will run in CI)
- [x] Integration tests against Airflow 3.x (will run in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)