### PR TITLE
chore: remove stale config and fix documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,17 @@ test-integration:  ## Run integration tests against a running Airflow instance
 
 test-integration-v2:  ## Start Airflow 2.x and run integration tests
 	docker compose -f docker-compose.test.yml --profile airflow2 up -d --wait
-	./scripts/run-integration-tests.sh http://localhost:8080 admin admin || true
-	docker compose -f docker-compose.test.yml --profile airflow2 down
+	./scripts/run-integration-tests.sh http://localhost:8080 admin admin; \
+	EXIT_CODE=$$?; \
+	docker compose -f docker-compose.test.yml --profile airflow2 down; \
+	exit $$EXIT_CODE
 
 test-integration-v3:  ## Start Airflow 3.x and run integration tests
 	docker compose -f docker-compose.test.yml --profile airflow3 up -d --wait
-	./scripts/run-integration-tests.sh http://localhost:8081 admin admin || true
-	docker compose -f docker-compose.test.yml --profile airflow3 down
+	./scripts/run-integration-tests.sh http://localhost:8081 admin admin; \
+	EXIT_CODE=$$?; \
+	docker compose -f docker-compose.test.yml --profile airflow3 down; \
+	exit $$EXIT_CODE
 
 test-all:  ## Run unit tests + integration tests against both Airflow versions
 	$(MAKE) test

--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ Configure in Cursor's MCP settings:
 | `list_providers` | Get installed provider packages |
 | `get_airflow_config` | Get Airflow configuration |
 | `get_airflow_version` | Get Airflow version information |
-| `get_health` | Get Airflow health status |
 
 ### MCP Resources
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,6 @@ fallback-version = "0.0.0+dev"
 [tool.hatchling.build.targets.wheel]
 packages = ["src/astro_airflow_mcp"]
 
-[tool.hatchling.build.targets.wheel.force-include]
-"src/astro_airflow_mcp/templates" = "astro_airflow_mcp/templates"
-
 [dependency-groups]
 dev = [
     "pytest>=7.0.0",

--- a/src/astro_airflow_mcp/models.py
+++ b/src/astro_airflow_mcp/models.py
@@ -1,4 +1,14 @@
-"""Pydantic models for Airflow API responses."""
+"""Pydantic models for Airflow API responses.
+
+These models serve as type references and documentation for the expected
+API response structures. The adapters currently return raw dict[str, Any]
+for flexibility, but these models document the expected fields and types.
+
+They can be used for:
+- Type hints and IDE autocompletion during development
+- Documentation of API response structures
+- Future validation if stricter typing is desired
+"""
 
 from datetime import datetime
 from typing import Any


### PR DESCRIPTION
## Summary

Cleanup of stale configuration, documentation fixes, and improved error handling in the build/test pipeline.

## Changes

### 1. Remove stale templates force-include (pyproject.toml)

The `[tool.hatchling.build.targets.wheel.force-include]` section referenced `src/astro_airflow_mcp/templates` which does not exist. This was likely left over from an earlier iteration. Removed to prevent potential build issues.

### 2. Remove non-existent `get_health` from README

The tools table listed `get_health` but this tool doesn't exist in the codebase. Only `get_system_health` (the consolidated tool) exists.

### 3. Add documentation to models.py

Added a module docstring explaining that the Pydantic models serve as type references and documentation rather than being actively used for validation.

**Why keep unused models?**
- They document the expected API response structures
- Enable IDE autocompletion during development
- Provide a foundation if we want stricter typing in the future

**Future consideration:** See #18 for discussion on using these models for response validation.

### 4. Fix Makefile integration test error handling

The integration test targets used `|| true` which silently swallowed test failures. This meant CI would pass even when integration tests failed.

Changed to properly capture the exit code, run cleanup (docker-compose down), and then exit with the original test result.