### PR TITLE
docs: restructure README with improved MCP client configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,122 @@
 [![PyPI - Version](https://img.shields.io/pypi/v/astro-airflow-mcp.svg?color=blue)](https://pypi.org/project/astro-airflow-mcp)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://github.com/astronomer/astro-airflow-mcp/blob/main/LICENSE)
 
-A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for Apache Airflow that provides AI assistants (like Claude, Cursor, etc.) with access to Airflow's REST API. Built with [FastMCP](https://github.com/jlowin/fastmcp).
+A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for Apache Airflow that provides AI assistants with access to Airflow's REST API. Built with [FastMCP](https://github.com/jlowin/fastmcp).
+
+## Quickstart
+
+### IDEs
+
+[<img src="https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white" alt="Install in VS Code" height="32">](https://insiders.vscode.dev/redirect?url=vscode://ms-vscode.vscode-mcp/install?%7B%22name%22%3A%22astro-airflow-mcp%22%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22astro-airflow-mcp%22%2C%22--transport%22%2C%22stdio%22%5D%7D)
+[<img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Add to Cursor" height="32">](cursor://anysphere.cursor-deeplink/mcp/install?name=astro-airflow-mcp&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJhc3Ryby1haXJmbG93LW1jcCIsIi0tdHJhbnNwb3J0Iiwic3RkaW8iXX0)
+
+<details>
+<summary>Manual configuration</summary>
+
+Add to your MCP settings (Cursor: `~/.cursor/mcp.json`, VS Code: `.vscode/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "airflow": {
+      "command": "uvx",
+      "args": ["astro-airflow-mcp", "--transport", "stdio"]
+    }
+  }
+}
+```
+
+</details>
+
+### CLI Tools
+
+<details>
+<summary>Claude Code</summary>
+
+```bash
+claude mcp add airflow -- uvx astro-airflow-mcp --transport stdio
+```
+
+</details>
+
+<details>
+<summary>Gemini CLI</summary>
+
+```bash
+gemini mcp add airflow -- uvx astro-airflow-mcp --transport stdio
+```
+
+</details>
+
+<details>
+<summary>Codex CLI</summary>
+
+```bash
+codex mcp add airflow -- uvx astro-airflow-mcp --transport stdio
+```
+
+</details>
+
+### Desktop Apps
+
+<details>
+<summary>Claude Desktop</summary>
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "airflow": {
+      "command": "uvx",
+      "args": ["astro-airflow-mcp", "--transport", "stdio"]
+    }
+  }
+}
+```
+
+</details>
+
+### Other MCP Clients
+
+<details>
+<summary>Manual JSON Configuration</summary>
+
+Add to your MCP configuration file:
+
+```json
+{
+  "mcpServers": {
+    "airflow": {
+      "command": "uvx",
+      "args": ["astro-airflow-mcp", "--transport", "stdio"]
+    }
+  }
+}
+```
+
+Or connect to a running HTTP server: `"url": "http://localhost:8000/mcp"`
+
+</details>
+
+> **Note:** No installation required - `uvx` runs directly from PyPI. The `--transport stdio` flag is required because the server defaults to HTTP mode.
+
+### Configuration
+
+By default, the server connects to `http://localhost:8080` (Astro CLI default). Set environment variables for custom Airflow instances:
+
+| Variable | Description |
+|----------|-------------|
+| `AIRFLOW_API_URL` | Airflow webserver URL |
+| `AIRFLOW_USERNAME` | Username (Airflow 3.x uses OAuth2 token exchange) |
+| `AIRFLOW_PASSWORD` | Password |
+| `AIRFLOW_AUTH_TOKEN` | Bearer token (alternative to username/password) |
+
+Example with auth (Claude Code):
+
+```bash
+claude mcp add airflow -e AIRFLOW_API_URL=https://your-airflow.example.com -e AIRFLOW_USERNAME=admin -e AIRFLOW_PASSWORD=admin -- uvx astro-airflow-mcp --transport stdio
+```
 
 ## Features
 
@@ -32,133 +147,6 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for Ap
   - Bearer token (Airflow 2.x and 3.x)
   - Username/password with automatic OAuth2 token exchange (Airflow 3.x)
   - Basic auth (Airflow 2.x)
-
-
-## Installation
-
-We recommend installing astro-airflow-mcp with [uv](https://docs.astral.sh/uv/):
-
-```bash
-uv pip install astro-airflow-mcp
-```
-
-If installing into an Astro project as an Airflow plugin, add the package to your `requirements.txt`:
-
-```bash
-echo astro-airflow-mcp >> requirements.txt
-```
-
-## Usage
-
-### Running the Server
-
-After installation, start the MCP server:
-
-```bash
-astro-airflow-mcp
-```
-
-By default, this will:
-- Start an HTTP server on `localhost:8000`
-- Connect to Airflow at `http://localhost:8080` (`astro dev start`)
-- Expose MCP protocol endpoints at `http://localhost:8000/mcp`
-
-The server provides a set of tools that AI assistants can use to interact with your Airflow instance through the REST API. No authentication is required by default, but you can configure it using environment variables or command-line flags (see [Configuration](#configuration)).
-
-**Custom configuration:**
-
-```bash
-# Airflow 3.x with username/password (OAuth2 token exchange)
-astro-airflow-mcp --airflow-url https://my-airflow.example.com --username admin --password admin
-
-# Airflow 2.x or 3.x with bearer token
-astro-airflow-mcp --airflow-url https://my-airflow.example.com --auth-token my_token
-
-# Use a different port
-astro-airflow-mcp --port 9000
-
-# Use stdio mode (for Claude Desktop)
-astro-airflow-mcp --transport stdio
-```
-
-### Using with MCP Clients
-
-#### Claude Desktop
-
-Add to your Claude Desktop configuration:
-
-```json
-{
-  "mcpServers": {
-    "airflow": {
-      "command": "astro-airflow-mcp",
-      "env": {
-        "AIRFLOW_API_URL": "http://your.airflow.domain.com",
-        "AIRFLOW_USERNAME": "admin",
-        "AIRFLOW_PASSWORD": "admin"
-      }
-    }
-  }
-}
-```
-
-Or with a bearer token:
-
-```json
-{
-  "mcpServers": {
-    "airflow": {
-      "command": "astro-airflow-mcp",
-      "env": {
-        "AIRFLOW_API_URL": "http://your.airflow.domain.com",
-        "AIRFLOW_AUTH_TOKEN": "your_token"
-      }
-    }
-  }
-}
-```
-
-#### Cursor
-
-Configure in Cursor's MCP settings:
-
-```json
-{
-  "mcpServers": {
-    "airflow": {
-      "command": "astro-airflow-mcp",
-      "args": [
-        "--transport",
-        "stdio"
-      ]
-    }
-  }
-}
-```
-
-**Or connect to the standalone server endpoint**:
-
-```json
-{
-  "mcpServers": {
-    "airflow": {
-      "url": "http://localhost:8000/mcp"
-    }
-  }
-}
-```
-
-**Or connect to the Airflow plugin endpoint**:
-
-```json
-{
-  "mcpServers": {
-    "airflow": {
-      "url": "http://localhost:8080/mcp/v1"
-    }
-  }
-}
-```
 
 ## Available Tools
 
@@ -217,54 +205,39 @@ Configure in Cursor's MCP settings:
 | `daily_health_check` | Morning health check routine |
 | `onboard_new_dag` | Guide for understanding a new DAG |
 
-## Development
+## Advanced Usage
 
-### Quick Start
+### Running as Standalone Server
 
-```bash
-# Setup development environment
-make setup
-
-# Run tests
-make test
-
-# Run all checks
-make check
-
-# Run prek hooks
-make prek
-```
-
-### Local Testing with Astro CLI
-
-The easiest way to test the MCP server locally is with [Astro CLI](https://www.astronomer.io/docs/astro/cli/overview):
+For HTTP-based integrations or connecting multiple clients to one server:
 
 ```bash
-# Start a local Airflow instance locally with an astro project (optional but recommended)
-astro dev start
-
-# In another terminal, run the MCP server
-# It will automatically connect to http://localhost:8080
-make run
+# Run server (HTTP mode is default)
+uvx astro-airflow-mcp --airflow-url https://my-airflow.example.com --username admin --password admin
 ```
 
-The default configuration (`http://localhost:8080`) matches Astro CLI's default Airflow webserver URL, so `make run` works out of the box with no additional configuration needed.
+Connect MCP clients to: `http://localhost:8000/mcp`
 
-## Configuration
+### Airflow Plugin Mode
 
-All tools use a global configuration that can be set via:
+Install into your Airflow 3.x environment to expose MCP at `http://your-airflow:8080/mcp/v1`:
 
-1. **Command-line flags** (standalone mode):
-   - `--airflow-url`: Airflow webserver URL
-   - `--auth-token`: Bearer token for authentication
-   - `--username`: Username for authentication (Airflow 3.x uses OAuth2 token exchange)
-   - `--password`: Password for authentication
+```bash
+# Add to your Astro project
+echo astro-airflow-mcp >> requirements.txt
+```
 
-2. **Environment variables**:
-   - `AIRFLOW_API_URL`: Airflow webserver URL
-   - `AIRFLOW_AUTH_TOKEN`: Bearer token
-   - `AIRFLOW_USERNAME`: Username for authentication
-   - `AIRFLOW_PASSWORD`: Password for authentication
+### CLI Options
+
+| Flag | Environment Variable | Default | Description |
+|------|---------------------|---------|-------------|
+| `--transport` | `MCP_TRANSPORT` | `http` | Transport mode: `http` or `stdio` |
+| `--host` | `MCP_HOST` | `localhost` | Host to bind (HTTP mode) |
+| `--port` | `MCP_PORT` | `8000` | Port to bind (HTTP mode) |
+| `--airflow-url` | `AIRFLOW_API_URL` | `http://localhost:8080` | Airflow webserver URL |
+| `--auth-token` | `AIRFLOW_AUTH_TOKEN` | - | Bearer token |
+| `--username` | `AIRFLOW_USERNAME` | - | Username |
+| `--password` | `AIRFLOW_PASSWORD` | - | Password |
 
 ## Architecture
 
@@ -289,6 +262,23 @@ The server is built using [FastMCP](https://github.com/jlowin/fastmcp) with an a
 
 - **Standalone**: Independent ASGI application with HTTP/SSE transport
 - **Plugin**: Mounted into Airflow 3.x FastAPI webserver
+
+## Development
+
+```bash
+# Setup development environment
+make install-dev
+
+# Run tests
+make test
+
+# Run all checks
+make check
+
+# Local testing with Astro CLI
+astro dev start  # Start Airflow
+make run         # Run MCP server (connects to localhost:8080)
+```
 
 ## Contributing
 


### PR DESCRIPTION
Restructures README for better discoverability:

- **Quickstart** with one-click install buttons for VS Code and Cursor
- Manual JSON config in dropdown for those who prefer it or if buttons don't work
- CLI commands for Claude Code, Gemini CLI, and Codex CLI
- Dropdowns reduce visual clutter
- Adds CLI options reference table
- Moves standalone server docs to Advanced Usage

Config explicitly includes `--transport stdio` (server defaults to HTTP).