### PR TITLE
Add additional ruff rules inspired by Apache Airflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     rev: v0.14.7
     hooks:
       # Run the linter
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       # Run the formatter
       - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,26 +49,37 @@ line-length = 100
 target-version = "py310"
 
 [tool.ruff.lint]
-select = [
-    "E",   # pycodestyle errors
-    "W",   # pycodestyle warnings
-    "F",   # pyflakes
-    "I",   # isort
-    "B",   # flake8-bugbear
-    "C4",  # flake8-comprehensions
-    "UP",  # pyupgrade
-    "ARG", # flake8-unused-arguments
-    "SIM", # flake8-simplify
+extend-select = [
+    "E",      # pycodestyle errors
+    "W",      # pycodestyle warnings
+    "F",      # pyflakes
+    "I",      # isort
+    "B",      # flake8-bugbear
+    "C4",     # flake8-comprehensions
+    "UP",     # pyupgrade
+    "ARG",    # flake8-unused-arguments
+    "SIM",    # flake8-simplify
+    "ISC",    # implicit string concatenation
+    "LOG",    # flake8-logging
+    "TC",     # type-checking imports
+    "G",      # flake8-logging-format
+    "RET",    # flake8-return
+    "PIE",    # flake8-pie (PIE790: unnecessary pass)
+    "PT",     # flake8-pytest-style
+    "RUF",    # Ruff-specific rules
+    "ASYNC",  # flake8-async
+    "TID252", # relative imports from parent
 ]
 ignore = [
-    "E501",  # line too long (handled by formatter)
-    "B008",  # do not perform function calls in argument defaults
+    "E501",   # line too long (handled by formatter)
+    "B008",   # do not perform function calls in argument defaults
     "ARG002", # unused method argument
+    "RUF012", # mutable class attributes (common pattern)
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # Allow unused imports in __init__.py
-"tests/**/*.py" = ["ARG001", "ARG002"]  # Allow unused arguments in tests
+"tests/**/*.py" = ["ARG001", "ARG002", "PT011"]  # Allow unused arguments and broad pytest.raises in tests
 
 [tool.bandit]
 exclude_dirs = ["tests", "examples"]

--- a/src/astro_airflow_mcp/__main__.py
+++ b/src/astro_airflow_mcp/__main__.py
@@ -73,11 +73,11 @@ def main():
     )
 
     # Log Airflow connection configuration
-    logger.info(f"Airflow URL: {args.airflow_url}")
+    logger.info("Airflow URL: %s", args.airflow_url)
     if args.auth_token:
         logger.info("Authentication: Direct bearer token")
     elif args.username:
-        logger.info(f"Authentication: Token manager (username: {args.username})")
+        logger.info("Authentication: Token manager (username: %s)", args.username)
     else:
         logger.info("Authentication: Token manager (credential-less mode)")
 

--- a/src/astro_airflow_mcp/adapters/__init__.py
+++ b/src/astro_airflow_mcp/adapters/__init__.py
@@ -108,15 +108,14 @@ def create_adapter(
             token_getter=token_getter,
             basic_auth_getter=basic_auth_getter,
         )
-    elif major_version >= 3:
+    if major_version >= 3:
         return AirflowV3Adapter(
             airflow_url,
             full_version,
             token_getter=token_getter,
             basic_auth_getter=basic_auth_getter,
         )
-    else:
-        raise RuntimeError(f"Unsupported Airflow version: {major_version}")
+    raise RuntimeError(f"Unsupported Airflow version: {major_version}")
 
 
 __all__ = [

--- a/src/astro_airflow_mcp/adapters/airflow_v3.py
+++ b/src/astro_airflow_mcp/adapters/airflow_v3.py
@@ -238,9 +238,8 @@ class AirflowV3Adapter(AirflowAdapter):
                 if not all_results["errors"]:
                     del all_results["errors"]
                 return all_results
-            else:
-                # Pass empty dag_ids to avoid 500 error
-                return self._call("dagStats", params={"dag_ids": ""})
+            # Pass empty dag_ids to avoid 500 error
+            return self._call("dagStats", params={"dag_ids": ""})
         except NotFoundError:
             return self._handle_not_found(
                 "dagStats", alternative="Use list_dag_runs to compute statistics"

--- a/src/astro_airflow_mcp/adapters/base.py
+++ b/src/astro_airflow_mcp/adapters/base.py
@@ -47,7 +47,6 @@ class AirflowAdapter(ABC):
     @abstractmethod
     def api_base_path(self) -> str:
         """API base path for this version (e.g., '/api/v1' or '/api/v2')."""
-        pass
 
     def _setup_auth(self) -> tuple[dict[str, str], tuple[str, str] | None]:
         """Set up authentication using token or basic auth.
@@ -213,17 +212,14 @@ class AirflowAdapter(ABC):
     @abstractmethod
     def list_dags(self, limit: int = 100, offset: int = 0, **kwargs: Any) -> dict[str, Any]:
         """List all DAGs."""
-        pass
 
     @abstractmethod
     def get_dag(self, dag_id: str) -> dict[str, Any]:
         """Get details of a specific DAG."""
-        pass
 
     @abstractmethod
     def get_dag_source(self, dag_id: str) -> dict[str, Any]:
         """Get source code of a DAG."""
-        pass
 
     @abstractmethod
     def pause_dag(self, dag_id: str) -> dict[str, Any]:
@@ -235,7 +231,6 @@ class AirflowAdapter(ABC):
         Returns:
             Updated DAG details with is_paused=True
         """
-        pass
 
     @abstractmethod
     def unpause_dag(self, dag_id: str) -> dict[str, Any]:
@@ -247,7 +242,6 @@ class AirflowAdapter(ABC):
         Returns:
             Updated DAG details with is_paused=False
         """
-        pass
 
     # DAG Run Operations
     @abstractmethod
@@ -255,12 +249,10 @@ class AirflowAdapter(ABC):
         self, dag_id: str | None = None, limit: int = 100, offset: int = 0, **kwargs: Any
     ) -> dict[str, Any]:
         """List DAG runs."""
-        pass
 
     @abstractmethod
     def get_dag_run(self, dag_id: str, dag_run_id: str) -> dict[str, Any]:
         """Get details of a specific DAG run."""
-        pass
 
     @abstractmethod
     def trigger_dag_run(
@@ -276,23 +268,19 @@ class AirflowAdapter(ABC):
         Returns:
             Details of the triggered DAG run
         """
-        pass
 
     # Task Operations
     @abstractmethod
     def list_tasks(self, dag_id: str) -> dict[str, Any]:
         """List all tasks in a DAG."""
-        pass
 
     @abstractmethod
     def get_task(self, dag_id: str, task_id: str) -> dict[str, Any]:
         """Get details of a specific task."""
-        pass
 
     @abstractmethod
     def get_task_instance(self, dag_id: str, dag_run_id: str, task_id: str) -> dict[str, Any]:
         """Get details of a task instance."""
-        pass
 
     @abstractmethod
     def get_task_instances(
@@ -306,7 +294,6 @@ class AirflowAdapter(ABC):
             limit: Maximum number of task instances to return
             offset: Offset for pagination
         """
-        pass
 
     @abstractmethod
     def get_task_logs(
@@ -328,41 +315,34 @@ class AirflowAdapter(ABC):
             map_index: Map index for mapped tasks (-1 for unmapped, default -1)
             full_content: Whether to return full log content (default True)
         """
-        pass
 
     # Asset/Dataset Operations
     @abstractmethod
     def list_assets(self, limit: int = 100, offset: int = 0, **kwargs: Any) -> dict[str, Any]:
         """List assets/datasets."""
-        pass
 
     # Variable Operations
     @abstractmethod
     def list_variables(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
         """List Airflow variables."""
-        pass
 
     @abstractmethod
     def get_variable(self, variable_key: str) -> dict[str, Any]:
         """Get a specific variable."""
-        pass
 
     # Connection Operations
     @abstractmethod
     def list_connections(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
         """List Airflow connections (passwords filtered)."""
-        pass
 
     # Pool Operations
     @abstractmethod
     def list_pools(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
         """List Airflow pools."""
-        pass
 
     @abstractmethod
     def get_pool(self, pool_name: str) -> dict[str, Any]:
         """Get details of a specific pool."""
-        pass
 
     # DAG Statistics and Warnings
     @abstractmethod
@@ -372,36 +352,29 @@ class AirflowAdapter(ABC):
         Args:
             dag_ids: Optional list of DAG IDs to get stats for.
         """
-        pass
 
     @abstractmethod
     def list_dag_warnings(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
         """List DAG warnings."""
-        pass
 
     @abstractmethod
     def list_import_errors(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
         """List import errors from DAG files."""
-        pass
 
     # Plugin and Provider Operations
     @abstractmethod
     def list_plugins(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
         """List installed Airflow plugins."""
-        pass
 
     @abstractmethod
     def list_providers(self) -> dict[str, Any]:
         """List installed Airflow provider packages."""
-        pass
 
     # System Operations
     @abstractmethod
     def get_version(self) -> dict[str, Any]:
         """Get Airflow version info."""
-        pass
 
     @abstractmethod
     def get_config(self) -> dict[str, Any]:
         """Get Airflow configuration."""
-        pass

--- a/src/astro_airflow_mcp/plugin.py
+++ b/src/astro_airflow_mcp/plugin.py
@@ -44,7 +44,7 @@ try:
     fastapi_apps_config = [{"app": app, "url_prefix": "/mcp", "name": "Airflow MCP Server"}]
 
 except ImportError as e:
-    logger.warning(f"FastAPI integration not available: {e}")
+    logger.warning("FastAPI integration not available: %s", e)
     fastapi_apps_config = []
 
 

--- a/src/astro_airflow_mcp/server.py
+++ b/src/astro_airflow_mcp/server.py
@@ -162,11 +162,11 @@ class AirflowTokenManager:
                     self._token_lifetime_seconds = float(data["expires_in"])
                 logger.info("Successfully fetched Airflow API token")
             else:
-                logger.warning(f"Unexpected token response format: {data}")
+                logger.warning("Unexpected token response format: %s", data)
                 self._token = None
 
         except httpx.RequestError as e:
-            logger.warning(f"Failed to fetch token from {token_url}: {e}")
+            logger.warning("Failed to fetch token from %s: %s", token_url, e)
             self._token = None
 
     def invalidate(self) -> None:
@@ -226,13 +226,13 @@ def _get_adapter() -> AirflowAdapter:
     """
     global _adapter
     if _adapter is None:
-        logger.info(f"Initializing adapter for {_config.url}")
+        logger.info("Initializing adapter for %s", _config.url)
         _adapter = create_adapter(
             airflow_url=_config.url,
             token_getter=_get_auth_token,
             basic_auth_getter=_get_basic_auth,
         )
-        logger.info(f"Created adapter for Airflow {_adapter.version}")
+        logger.info("Created adapter for Airflow %s", _adapter.version)
     return _adapter
 
 
@@ -417,8 +417,7 @@ def _list_dags_impl(
 
         if "dags" in data:
             return _wrap_list_response(data["dags"], "dags", data)
-        else:
-            return f"No DAGs found. Response: {data}"
+        return f"No DAGs found. Response: {data}"
     except Exception as e:
         return str(e)
 
@@ -553,8 +552,7 @@ def _list_dag_warnings_impl(
 
         if "dag_warnings" in data:
             return _wrap_list_response(data["dag_warnings"], "dag_warnings", data)
-        else:
-            return f"No DAG warnings found. Response: {data}"
+        return f"No DAG warnings found. Response: {data}"
     except Exception as e:
         return str(e)
 
@@ -578,8 +576,7 @@ def _list_import_errors_impl(
 
         if "import_errors" in data:
             return _wrap_list_response(data["import_errors"], "import_errors", data)
-        else:
-            return f"No import errors found. Response: {data}"
+        return f"No import errors found. Response: {data}"
     except Exception as e:
         return str(e)
 
@@ -670,8 +667,7 @@ def _list_tasks_impl(dag_id: str) -> str:
 
         if "tasks" in data:
             return _wrap_list_response(data["tasks"], "tasks", data)
-        else:
-            return f"No tasks found. Response: {data}"
+        return f"No tasks found. Response: {data}"
     except Exception as e:
         return str(e)
 
@@ -899,8 +895,7 @@ def _list_dag_runs_impl(
 
         if "dag_runs" in data:
             return _wrap_list_response(data["dag_runs"], "dag_runs", data)
-        else:
-            return f"No DAG runs found. Response: {data}"
+        return f"No DAG runs found. Response: {data}"
     except Exception as e:
         return str(e)
 
@@ -1355,8 +1350,7 @@ def _list_assets_impl(
 
         if "assets" in data:
             return _wrap_list_response(data["assets"], "assets", data)
-        else:
-            return f"No assets found. Response: {data}"
+        return f"No assets found. Response: {data}"
     except Exception as e:
         return str(e)
 
@@ -1438,8 +1432,7 @@ def _list_connections_impl(
             }
 
             return json.dumps(result, indent=2)
-        else:
-            return f"No connections found. Response: {data}"
+        return f"No connections found. Response: {data}"
     except Exception as e:
         return str(e)
 
@@ -1514,8 +1507,7 @@ def _list_variables_impl(
 
         if "variables" in data:
             return _wrap_list_response(data["variables"], "variables", data)
-        else:
-            return f"No variables found. Response: {data}"
+        return f"No variables found. Response: {data}"
     except Exception as e:
         return str(e)
 
@@ -1548,8 +1540,7 @@ def _get_config_impl() -> str:
             # Add summary metadata and pass through sections
             result = {"total_sections": len(data["sections"]), "sections": data["sections"]}
             return json.dumps(result, indent=2)
-        else:
-            return f"No configuration found. Response: {data}"
+        return f"No configuration found. Response: {data}"
     except Exception as e:
         return str(e)
 
@@ -1592,8 +1583,7 @@ def _list_pools_impl(
 
         if "pools" in data:
             return _wrap_list_response(data["pools"], "pools", data)
-        else:
-            return f"No pools found. Response: {data}"
+        return f"No pools found. Response: {data}"
     except Exception as e:
         return str(e)
 
@@ -1617,8 +1607,7 @@ def _list_plugins_impl(
 
         if "plugins" in data:
             return _wrap_list_response(data["plugins"], "plugins", data)
-        else:
-            return f"No plugins found. Response: {data}"
+        return f"No plugins found. Response: {data}"
     except Exception as e:
         return str(e)
 
@@ -1635,8 +1624,7 @@ def _list_providers_impl() -> str:
 
         if "providers" in data:
             return _wrap_list_response(data["providers"], "providers", data)
-        else:
-            return f"No providers found. Response: {data}"
+        return f"No providers found. Response: {data}"
     except Exception as e:
         return str(e)
 

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -173,7 +173,7 @@ class TestResourceEndpoints:
                 assert conn["password"] in (
                     None,
                     "",
-                    "***FILTERED***",  # noqa: S105
+                    "***FILTERED***",
                 ), f"Password not filtered for {conn.get('connection_id')}"
         print(f"Found {len(result['connections'])} connections")
 


### PR DESCRIPTION
## Changes

- Add new ruff rule categories: `PIE`, `PT`, `RUF`, `ASYNC`, `TID252`
- Fix `G004` violations by converting f-string logging to lazy `%` formatting
- Remove unnecessary `pass` statements after docstrings in abstract methods (`PIE790`)
- Remove unused `noqa` directive (`RUF100`)
- Clean up unnecessary `else` after `return` (`RET`)

Rules added from [Apache Airflow's pyproject.toml](https://github.com/apache/airflow/blob/main/pyproject.toml).