### PR TITLE
Update default mode from http to stdio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,17 +24,17 @@ install-hooks:  ## Install pre-commit hooks
 	pre-commit install
 	@echo "✓ Pre-commit hooks installed"
 
-run:  ## Run the MCP server (defaults: http mode, localhost:8000, airflow at localhost:8080)
-	uv run python -m astro_airflow_mcp
+run:  ## Run the MCP server in HTTP mode (default is stdio, but HTTP can be useful for local testing)
+	uv run python -m astro_airflow_mcp --transport http
 
 docker-build:  ## Build Docker image
 	docker build -t astro-airflow-mcp .
 
-docker-run:  ## Run Docker container (http mode with 0.0.0.0 binding for container access)
+docker-run:  ## Run Docker container
 	docker run -p 8000:8000 \
 		-e AIRFLOW_API_URL=http://host.docker.internal:8080 \
 		astro-airflow-mcp \
-		python -m astro_airflow_mcp --host 0.0.0.0
+		python -m astro_airflow_mcp --transport http
 
 build:  ## Build distribution packages (wheel and sdist)
 	uv build

--- a/src/astro_airflow_mcp/__main__.py
+++ b/src/astro_airflow_mcp/__main__.py
@@ -17,9 +17,9 @@ def main():
     parser.add_argument(
         "--transport",
         type=str,
-        default=os.getenv("MCP_TRANSPORT", "http"),
+        default=os.getenv("MCP_TRANSPORT", "stdio"),
         choices=["stdio", "http"],
-        help="Transport mode: http (default) or stdio",
+        help="Transport mode: stdio (default) or http",
     )
     parser.add_argument(
         "--host",


### PR DESCRIPTION
## Summary
- Changed default MCP server mode from HTTP to stdio
- Updated README with new stdio usage instructions
- Modified Makefile and main entry point to support stdio by default
