### PR TITLE
feat: add project-dir auto-discovery for Airflow URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
       - id: mypy
         additional_dependencies:
           - types-requests
+          - types-PyYAML
         args: [--ignore-missing-imports, --no-strict-optional]
         exclude: ^tests/
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install-dev:  ## Install the package with dev dependencies (local)
 	uv sync --all-extras
 
 install-dev-ci:  ## Install the package with dev dependencies (CI - system Python)
-	uv export --no-hashes --format requirements-txt --all-extras > /tmp/requirements.txt
+	uv export --no-hashes --format requirements-txt --all-extras --all-groups > /tmp/requirements.txt
 	uv pip install --system -r /tmp/requirements.txt
 	uv pip install --system -e .
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ echo astro-airflow-mcp >> requirements.txt
 | `--transport` | `MCP_TRANSPORT` | `stdio` | Transport mode (`stdio` or `http`) |
 | `--host` | `MCP_HOST` | `localhost` | Host to bind to (HTTP mode only) |
 | `--port` | `MCP_PORT` | `8000` | Port to bind to (HTTP mode only) |
-| `--airflow-url` | `AIRFLOW_API_URL` | `http://localhost:8080` | Airflow webserver URL |
+| `--airflow-url` | `AIRFLOW_API_URL` | Auto-discovered or `http://localhost:8080` | Airflow webserver URL |
+| `--airflow-project-dir` | `AIRFLOW_PROJECT_DIR` | `$PWD` | Astro project directory for auto-discovering Airflow URL from `.astro/config.yaml` |
 | `--auth-token` | `AIRFLOW_AUTH_TOKEN` | `None` | Bearer token for authentication |
 | `--username` | `AIRFLOW_USERNAME` | `None` | Username for authentication (Airflow 3.x uses OAuth2 token exchange) |
 | `--password` | `AIRFLOW_PASSWORD` | `None` | Password for authentication |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "fastmcp>=0.1.0",
     "httpx>=0.27.0",
     "pydantic>=2.0.0",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "prek>=0.2.0",
     "mypy>=1.8.0",
     "bandit[toml]>=1.7.0",
+    "types-PyYAML>=6.0",
 ]
 
 [tool.ruff]

--- a/src/astro_airflow_mcp/__main__.py
+++ b/src/astro_airflow_mcp/__main__.py
@@ -107,10 +107,10 @@ def main():
         help="Password for Airflow API token authentication",
     )
     parser.add_argument(
-        "--project-dir",
+        "--airflow-project-dir",
         type=str,
-        default=os.getenv("PROJECT_DIR") or os.getenv("PWD") or os.getcwd(),
-        help="Project directory where Claude Code is running (default: $PWD)",
+        default=os.getenv("AIRFLOW_PROJECT_DIR") or os.getenv("PWD") or os.getcwd(),
+        help="Astro project directory for auto-discovering Airflow URL from .astro/config.yaml (default: $PWD)",
     )
 
     args = parser.parse_args()
@@ -124,7 +124,7 @@ def main():
     url_source = "explicit"
     if not airflow_url:
         # Try auto-discovery from .astro/config.yaml
-        airflow_url = discover_airflow_url(args.project_dir)
+        airflow_url = discover_airflow_url(args.airflow_project_dir)
         if airflow_url:
             url_source = "auto-discovered"
         else:
@@ -137,11 +137,11 @@ def main():
         auth_token=args.auth_token,
         username=args.username,
         password=args.password,
-        project_dir=args.project_dir,
+        project_dir=args.airflow_project_dir,
     )
 
     # Log configuration
-    logger.info("Project directory: %s", args.project_dir)
+    logger.info("Project directory: %s", args.airflow_project_dir)
     logger.info("Airflow URL: %s (%s)", airflow_url, url_source)
     if args.auth_token:
         logger.info("Authentication: Direct bearer token")

--- a/src/astro_airflow_mcp/__main__.py
+++ b/src/astro_airflow_mcp/__main__.py
@@ -3,11 +3,60 @@
 import argparse
 import logging
 import os
+from pathlib import Path
+
+import yaml
 
 from astro_airflow_mcp.logging import configure_logging, get_logger
 from astro_airflow_mcp.server import configure, mcp
 
 logger = get_logger("main")
+
+# Default Airflow URL if no config is found
+DEFAULT_AIRFLOW_URL = "http://localhost:8080"
+
+
+def discover_airflow_url(project_dir: str | None) -> str | None:
+    """Discover Airflow URL from .astro/config.yaml in the project directory.
+
+    Looks for the Astro CLI config file and extracts the webserver/api-server port.
+    Prefers api-server.port (Airflow 3.x) over webserver.port (Airflow 2.x).
+
+    Args:
+        project_dir: The project directory to search in
+
+    Returns:
+        The discovered Airflow URL (e.g., "http://localhost:8081"), or None if not found
+    """
+    if not project_dir:
+        return None
+
+    config_path = Path(project_dir) / ".astro" / "config.yaml"
+    if not config_path.exists():
+        return None
+
+    try:
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+
+        if not config:
+            return None
+
+        # Try api-server.port first (Airflow 3.x), then webserver.port (Airflow 2.x)
+        port = None
+        if "api-server" in config and isinstance(config["api-server"], dict):
+            port = config["api-server"].get("port")
+        if port is None and "webserver" in config and isinstance(config["webserver"], dict):
+            port = config["webserver"].get("port")
+
+        if port:
+            return f"http://localhost:{port}"
+
+    except Exception as e:
+        # Log but don't fail - we'll fall back to default
+        logger.debug("Failed to read .astro/config.yaml: %s", e)
+
+    return None
 
 
 def main():
@@ -36,8 +85,8 @@ def main():
     parser.add_argument(
         "--airflow-url",
         type=str,
-        default=os.getenv("AIRFLOW_API_URL", "http://localhost:8080"),
-        help="Base URL of Airflow webserver (default: http://localhost:8080)",
+        default=os.getenv("AIRFLOW_API_URL"),  # None if not set
+        help="Base URL of Airflow webserver (auto-discovered from .astro/config.yaml if not provided)",
     )
     parser.add_argument(
         "--auth-token",
@@ -57,6 +106,12 @@ def main():
         default=os.getenv("AIRFLOW_PASSWORD"),
         help="Password for Airflow API token authentication",
     )
+    parser.add_argument(
+        "--project-dir",
+        type=str,
+        default=os.getenv("PROJECT_DIR") or os.getenv("PWD") or os.getcwd(),
+        help="Project directory where Claude Code is running (default: $PWD)",
+    )
 
     args = parser.parse_args()
 
@@ -64,16 +119,30 @@ def main():
     stdio_mode = args.transport == "stdio"
     configure_logging(level=logging.INFO, stdio_mode=stdio_mode)
 
+    # Determine Airflow URL: explicit > auto-discover > default
+    airflow_url = args.airflow_url
+    url_source = "explicit"
+    if not airflow_url:
+        # Try auto-discovery from .astro/config.yaml
+        airflow_url = discover_airflow_url(args.project_dir)
+        if airflow_url:
+            url_source = "auto-discovered"
+        else:
+            airflow_url = DEFAULT_AIRFLOW_URL
+            url_source = "default"
+
     # Configure Airflow connection settings
     configure(
-        url=args.airflow_url,
+        url=airflow_url,
         auth_token=args.auth_token,
         username=args.username,
         password=args.password,
+        project_dir=args.project_dir,
     )
 
-    # Log Airflow connection configuration
-    logger.info("Airflow URL: %s", args.airflow_url)
+    # Log configuration
+    logger.info("Project directory: %s", args.project_dir)
+    logger.info("Airflow URL: %s (%s)", airflow_url, url_source)
     if args.auth_token:
         logger.info("Authentication: Direct bearer token")
     elif args.username:

--- a/src/astro_airflow_mcp/server.py
+++ b/src/astro_airflow_mcp/server.py
@@ -207,6 +207,7 @@ class AirflowConfig:
         self.url: str = DEFAULT_AIRFLOW_URL
         self.auth_token: str | None = None
         self.token_manager: AirflowTokenManager | None = None
+        self.project_dir: str | None = None
 
 
 _config = AirflowConfig()
@@ -247,6 +248,7 @@ def configure(
     auth_token: str | None = None,
     username: str | None = None,
     password: str | None = None,
+    project_dir: str | None = None,
 ) -> None:
     """Configure global Airflow connection settings.
 
@@ -255,6 +257,7 @@ def configure(
         auth_token: Direct bearer token for authentication (takes precedence)
         username: Username for token-based authentication
         password: Password for token-based authentication
+        project_dir: Project directory where Claude Code is running
 
     Note:
         If auth_token is provided, it will be used directly.
@@ -262,6 +265,8 @@ def configure(
         will be created to fetch and refresh tokens automatically.
         If neither is provided, credential-less token fetch will be attempted.
     """
+    if project_dir:
+        _config.project_dir = project_dir
     if url:
         _config.url = url
     if auth_token:
@@ -313,6 +318,15 @@ def _get_basic_auth() -> tuple[str, str] | None:
     if _config.token_manager:
         return _config.token_manager.get_basic_auth()
     return None
+
+
+def get_project_dir() -> str | None:
+    """Get the configured project directory.
+
+    Returns:
+        The project directory path, or None if not configured
+    """
+    return _config.project_dir
 
 
 def _invalidate_token() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.12'",
@@ -287,12 +288,12 @@ wheels = [
 
 [[package]]
 name = "astro-airflow-mcp"
-version = "0.1.9.dev2+g5e1c37066"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "pydantic" },
+    { name = "pyyaml" },
 ]
 
 [package.optional-dependencies]
@@ -301,15 +302,16 @@ plugin = [
     { name = "fastapi" },
 ]
 
-[package.dependency-groups]
+[package.dev-dependencies]
 dev = [
     { name = "bandit", extra = ["toml"] },
     { name = "mypy" },
-    { name = "pre-commit" },
+    { name = "prek" },
     { name = "pytest" },
     { name = "pytest-httpx" },
     { name = "pytest-mock" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -319,17 +321,20 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=0.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
+provides-extras = ["plugin"]
 
-[package.metadata.dependency-groups]
+[package.metadata.requires-dev]
 dev = [
     { name = "bandit", extras = ["toml"], specifier = ">=1.7.0" },
     { name = "mypy", specifier = ">=1.8.0" },
-    { name = "pre-commit", specifier = ">=3.5.0" },
+    { name = "prek", specifier = ">=0.2.0" },
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },
     { name = "pytest-mock", specifier = ">=3.12.0" },
     { name = "ruff", specifier = ">=0.1.0" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]
@@ -385,7 +390,7 @@ name = "bandit"
 version = "1.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "stevedore" },
@@ -528,15 +533,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cfgv"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445 },
-]
-
-[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -630,7 +626,7 @@ name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065 }
 wheels = [
@@ -796,15 +792,6 @@ wheels = [
 ]
 
 [[package]]
-name = "distlib"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047 },
-]
-
-[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -924,15 +911,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d4/a3/c9eb28b5f0b979b0dd8aa9ba56e69298cdb2d72c15592165d042ccb20194/fastmcp-2.13.1.tar.gz", hash = "sha256:b9c664c51f1ff47c698225e7304267ae29a51913f681bd49e442b8682f9a5f90", size = 8170226 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/4b/7e36db0a90044be181319ff025be7cc57089ddb6ba8f3712dea543b9cf97/fastmcp-2.13.1-py3-none-any.whl", hash = "sha256:7a78b19785c4ec04a758d920c312769a497e3f6ab4c80feed504df1ed7de9f3c", size = 376750 },
-]
-
-[[package]]
-name = "filelock"
-version = "3.20.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/46/0028a82567109b5ef6e4d2a1f04a583fb513e6cf9527fcdd09afd817deeb/filelock-3.20.0.tar.gz", hash = "sha256:711e943b4ec6be42e1d4e6690b48dc175c822967466bb31c0c293f34334c13f4", size = 18922 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/91/7216b27286936c16f5b4d0c530087e4a54eead683e6b0b73dd0c64844af6/filelock-3.20.0-py3-none-any.whl", hash = "sha256:339b4732ffda5cd79b13f4e2711a31b0365ce445d95d243bb996273d072546a2", size = 16054 },
 ]
 
 [[package]]
@@ -1179,15 +1157,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960 },
-]
-
-[[package]]
-name = "identify"
-version = "2.6.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ff/e7/685de97986c916a6d93b3876139e00eef26ad5bbbd61925d670ae8013449/identify-2.6.15.tar.gz", hash = "sha256:e4f4864b96c6557ef2a1e1c951771838f4edc9df3a72ec7118b338801b11c7bf", size = 99311 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/1c/e5fd8f973d4f375adb21565739498e2e9a1e54c858a97b9a8ccfdc81da9b/identify-2.6.15-py2.py3-none-any.whl", hash = "sha256:1181ef7608e00704db228516541eb83a88a9f94433a8c80bb9b5bd54b1d81757", size = 99183 },
 ]
 
 [[package]]
@@ -1818,15 +1787,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.9.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
-]
-
-[[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2077,19 +2037,27 @@ wheels = [
 ]
 
 [[package]]
-name = "pre-commit"
-version = "4.5.0"
+name = "prek"
+version = "0.2.28"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cfgv" },
-    { name = "identify" },
-    { name = "nodeenv" },
-    { name = "pyyaml" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/9b/6a4ffb4ed980519da959e1cf3122fc6cb41211daa58dbae1c73c0e519a37/pre_commit-4.5.0.tar.gz", hash = "sha256:dc5a065e932b19fc1d4c653c6939068fe54325af8e741e74e88db4d28a4dd66b", size = 198428 }
+sdist = { url = "https://files.pythonhosted.org/packages/54/d7/dda8a6b7819bdb9d1f54fa046911e80974d862bacba75a3539b43a9bb858/prek-0.2.28.tar.gz", hash = "sha256:ac54f58cad26e617a5c5459b705ff1cbaaa41640db03d8d35e39645aca1b82cf", size = 283945 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/c4/b2d28e9d2edf4f1713eb3c29307f1a63f3d67cf09bdda29715a36a68921a/pre_commit-4.5.0-py2.py3-none-any.whl", hash = "sha256:25e2ce09595174d9c97860a95609f9f852c0614ba602de3561e267547f2335e1", size = 226429 },
+    { url = "https://files.pythonhosted.org/packages/7e/8c/2e18867e31d06dfa4974bf31c4e597dc1d2b3671b3c04d85f1f6a32ebc74/prek-0.2.28-py3-none-linux_armv6l.whl", hash = "sha256:1705c0bd035379cb5f1d03c19481821363d72d7923303fe8c84fd8cc7c6c3318", size = 4802811 },
+    { url = "https://files.pythonhosted.org/packages/26/fa/6c6d0b0d8b2f21301da2bb3441f22232ed5a8cba1b63eeb18244d2192a2e/prek-0.2.28-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:67677c08767c278335b31ebcbf00c1c73e14eadd99a0d8537dfb43c54482673a", size = 4904156 },
+    { url = "https://files.pythonhosted.org/packages/fc/5a/aa071ef1c2e6c3f58b50d9138676c96dd6de2323a44e1a3e56e18d25c382/prek-0.2.28-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ffac92215058ea6ba954a8e3f978dcd2a5e89922a318fcb7035fb9c0ab4de395", size = 4630803 },
+    { url = "https://files.pythonhosted.org/packages/77/dc/66498e805a0bb17820de0c3575d75b202c66045a9bfeeff9305d9bedd126/prek-0.2.28-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:413c3da1c9b252b3fd5113f4a04c2dead3c793b0ec56fc55294bb797ba7ca056", size = 4826037 },
+    { url = "https://files.pythonhosted.org/packages/27/ad/99cccc9283c7b34cd92356fcb301a2b1c25a8b65dc34b86c671b0f8e29d8/prek-0.2.28-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e99639bb68b70704e7b3f7f1a51cb23527c4dbd4b8a01dfccaa70f26f8f6c58b", size = 4723658 },
+    { url = "https://files.pythonhosted.org/packages/53/13/ce3edc2dda7b65485612e08ab038b8dd1ef7b10a94b0193f527b19a5e246/prek-0.2.28-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:33c4a1b2a8a76581476ae327d6d4f1b0af6af42a90d436e21e45c72cb1081b81", size = 5044611 },
+    { url = "https://files.pythonhosted.org/packages/48/47/6405d7ad7959d9b57d56fec9a1b4b2e00abeb955084dd45d100fb50a8377/prek-0.2.28-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6236dda18152fc56b9f802ce2914fbb2d19f9891595d552228c7894004b3332f", size = 5511371 },
+    { url = "https://files.pythonhosted.org/packages/92/cc/108c227fae40268ece36b80e5649037f1a816518e9b6d585d128b263df79/prek-0.2.28-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6506709d9a52ee431d48b249b8b5fb93597a9511eb260ee85d868750425057f", size = 5099352 },
+    { url = "https://files.pythonhosted.org/packages/12/d6/156ad3996d3a078a1bc2c0839b8681634216a494dcb298b8751beb28b327/prek-0.2.28-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:7cc920c12613440c105a767dc19acf048e8a05342ba38b48450d673bea33bd62", size = 4834340 },
+    { url = "https://files.pythonhosted.org/packages/f4/06/c632d4c4bb9c63d25bcc26149f99c715206a40e414fb6b80e7f800ae2e2d/prek-0.2.28-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:322a1922e6d2fcb2a4c487e01b2613856dc3206269bdc317ad28770704159e63", size = 4844870 },
+    { url = "https://files.pythonhosted.org/packages/ba/03/763f62d292399ee962e2583e7bc3fd2f8ee2609813c89cc10ec89a39204c/prek-0.2.28-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:a07baefe3562371368135eac3c8b9cdb831bac17b83cb1b6a8f5688050918e6c", size = 4709011 },
+    { url = "https://files.pythonhosted.org/packages/e1/62/49397d1a5c2aaf5e7a8c0644be901ee97934a8a2cac0052652d01b7c6585/prek-0.2.28-py3-none-musllinux_1_1_i686.whl", hash = "sha256:17e95cab33067365028ffc1d4ab6c80c6c150f88e352d7c64bdc15e0570778f6", size = 4928435 },
+    { url = "https://files.pythonhosted.org/packages/5e/e8/8ec73b5bb3fb9d5daf77f181cc46c541bd476075c7613f9b4c9c953925cc/prek-0.2.28-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:bc5272e2e8d81438a3cd2785c3b14b6e73dcb8e61b8a2b7ce6e693d57f7181ac", size = 5209880 },
+    { url = "https://files.pythonhosted.org/packages/f3/52/a784a52bf72619bdfaafdbb6c964bda404b377213e7dc786f9ad6024501c/prek-0.2.28-py3-none-win32.whl", hash = "sha256:74657a1663191fb5f09f15873704c2d2640095ce56277d36860bbd08ba7eea94", size = 4622786 },
+    { url = "https://files.pythonhosted.org/packages/d0/b8/ec6aafefeb05ef3a0bfcc044d036890f2b732b90ed1426acbf1e33289a44/prek-0.2.28-py3-none-win_amd64.whl", hash = "sha256:c350046d623362db65e2be1455ef1c5a96ea476e235445752fa946a705f1c1c9", size = 5316389 },
+    { url = "https://files.pythonhosted.org/packages/df/3f/9d4aba92cb9199cad0b056de8292a78dcca1dc1f6a6a34550799f19bde3d/prek-0.2.28-py3-none-win_arm64.whl", hash = "sha256:81db6ba7e5cf1d5ceec7d3b04e01aded32b8db8f1238ad812ac6ebc0bd35f141", size = 4974627 },
 ]
 
 [[package]]
@@ -3193,6 +3161,15 @@ wheels = [
 ]
 
 [[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338 },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3328,21 +3305,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065 },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384 },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730 },
-]
-
-[[package]]
-name = "virtualenv"
-version = "20.35.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "distlib" },
-    { name = "filelock" },
-    { name = "platformdirs" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/20/28/e6f1a6f655d620846bd9df527390ecc26b3805a0c5989048c210e22c5ca9/virtualenv-20.35.4.tar.gz", hash = "sha256:643d3914d73d3eeb0c552cbb12d7e82adf0e504dbf86a3182f8771a153a1971c", size = 6028799 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/0c/c05523fa3181fdf0c9c52a6ba91a23fbf3246cc095f26f6516f9c60e6771/virtualenv-20.35.4-py3-none-any.whl", hash = "sha256:c21c9cede36c9753eeade68ba7d523529f228a403463376cf821eaae2b650f1b", size = 6005095 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `--project-dir` CLI argument that enables auto-discovery of the Airflow URL from `.astro/config.yaml`
- Useful when running with Claude Code plugins where the MCP server needs to connect to a local Astro CLI project
- Prefers `api-server.port` (Airflow 3.x) over `webserver.port` (Airflow 2.x)

## Changes
- New `--project-dir` argument (defaults to `$PWD`)
- Auto-discovers Airflow port from `.astro/config.yaml`
- Explicit `--airflow-url` takes precedence over auto-discovery
- Falls back to `http://localhost:8080` if no config found
- Added `pyyaml` dependency for config parsing
- Added `get_project_dir()` helper function for tools to access the configured project directory

## Example Usage
```bash
# Auto-discover from project directory
astro-airflow-mcp --project-dir /path/to/astro/project

# In .mcp.json (Claude Code plugin)
{
  "mcpServers": {
    "airflow": {
      "command": "uvx",
      "args": ["astro-airflow-mcp", "--transport", "stdio", "--project-dir", "${PWD}"]
    }
  }
}
```

## Test plan
- [x] Tested auto-discovery with sirius project (port 8081)
- [x] Verified explicit `--airflow-url` takes precedence
- [x] Verified default fallback when no `.astro/config.yaml` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)